### PR TITLE
Implement notebooks for g123-gwss, g123-calibration and ihs-gwss

### DIFF
--- a/workflow/notebooks/g123-calibration.ipynb
+++ b/workflow/notebooks/g123-calibration.ipynb
@@ -1,0 +1,320 @@
+{
+ "cells": [
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "id": "558a69f6-cc5c-4f18-be1f-bb216f865599",
+   "metadata": {},
+   "source": [
+    "# G123 window size calibration"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b58ec70a",
+   "metadata": {
+    "tags": [
+     "parameters"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "# Notebook parameters. Values here are for development only and \n",
+    "# will be overridden when running via snakemake and papermill.\n",
+    "cohort_id = 'BF-09_Houet_colu_2012_Q3'\n",
+    "cohorts_analysis=\"20230223\"\n",
+    "contigs = ['2L']\n",
+    "sample_sets = \"3.0\"\n",
+    "min_cohort_size = 20\n",
+    "max_cohort_size = 50\n",
+    "g123_calibration_contig = '3L'\n",
+    "use_gcs_cache = False\n",
+    "dask_scheduler = \"threads\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "87a7858c-e05a-47dc-ac14-7dff6afc0789",
+   "metadata": {},
+   "source": [
+    "## Setup"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a43f9a9b-f202-426f-830e-e430a8f762d7",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "import yaml\n",
+    "import pandas as pd\n",
+    "import malariagen_data\n",
+    "from pyprojroot import here\n",
+    "import numpy as np\n",
+    "import os\n",
+    "import dask\n",
+    "dask.config.set(scheduler=dask_scheduler);"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f608754e-203a-4bc1-9ba0-aacb02909f08",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "sample_sets"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "444cbbad-32b5-4e30-8e91-179b2fadaa6b",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "extra_params = dict()\n",
+    "if use_gcs_cache:\n",
+    "    extra_params[\"url\"] = \"simplecache::gs://vo_agam_release\"\n",
+    "    extra_params[\"simplecache\"] = dict(cache_storage=(here() / \"gcs_cache\").as_posix())\n",
+    "\n",
+    "ag3 = malariagen_data.Ag3(\n",
+    "    # pin the version of the cohorts analysis for reproducibility\n",
+    "    cohorts_analysis=cohorts_analysis,\n",
+    "    results_cache=(here() / \"malariagen_data_cache\").as_posix(),\n",
+    "    **extra_params,\n",
+    ")\n",
+    "ag3"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "165f3f10-8301-4b96-bf01-7639efbc47ca",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "df_cohorts = pd.read_csv(here() / \"build\" / \"cohorts.csv\").set_index(\"cohort_id\")\n",
+    "df_cohorts.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4b8994d6-1f03-4613-9aeb-1dffe9e3c745",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "cohort = df_cohorts.loc[cohort_id]\n",
+    "cohort"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ae14434e-fb63-40e2-b11f-445f10c0e8f2",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# determine the phasing analysis to use\n",
+    "cohort.taxon"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "795e6a08-85d3-4445-a729-d4064533e106",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "sample_query = cohort.sample_query\n",
+    "sample_query"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "53b4eb48-ccc9-443f-bd6d-d0595ea1b5cf",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "if cohort.taxon == 'arabiensis':\n",
+    "    site_mask = 'arab'\n",
+    "else:\n",
+    "    site_mask = 'gamb_colu'\n",
+    "site_mask"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "364bb11b-76c4-4e6e-b342-d41a9f07912c",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "contig = g123_calibration_contig\n",
+    "contig"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "32c68d4a-ba77-451e-957a-42fe3528a2ee",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "window_sizes = (100, 200, 500, 1000, 2000, 5000, 10000, 20000)\n",
+    "window_sizes"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1a281281-2954-46e3-9757-cb3e07b8a403",
+   "metadata": {},
+   "source": [
+    "## Run calibration"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b3bbf103-0a6b-453a-b564-4dc71a1682d1",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "ag3.plot_g123_calibration(\n",
+    "    contig=g123_calibration_contig,\n",
+    "    site_mask=site_mask,\n",
+    "    sample_sets=sample_sets,\n",
+    "    sample_query=sample_query,\n",
+    "    min_cohort_size=min_cohort_size,\n",
+    "    max_cohort_size=max_cohort_size,\n",
+    "    window_sizes=window_sizes,\n",
+    ");"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "57bf7410-1693-4e5e-ac0a-9f83880d34ba",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "calibration_runs = ag3.g123_calibration(\n",
+    "    contig=g123_calibration_contig,\n",
+    "    site_mask=site_mask,\n",
+    "    sample_sets=sample_sets,\n",
+    "    sample_query=sample_query,\n",
+    "    min_cohort_size=min_cohort_size,\n",
+    "    max_cohort_size=max_cohort_size,\n",
+    "    window_sizes=window_sizes,\n",
+    ")\n",
+    "calibration_runs"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "aa92376f-7073-43c9-a33d-5edab1628402",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "selected_window_size = None\n",
+    "for window_size in window_sizes:\n",
+    "    x = calibration_runs[str(window_size)]\n",
+    "    x95 = np.percentile(x, 95)\n",
+    "    if x95 < 0.1:\n",
+    "        selected_window_size = window_size\n",
+    "        break\n",
+    "selected_window_size"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5ba0820e-7797-48f8-aa48-366937a005bc",
+   "metadata": {},
+   "source": [
+    "## Write outputs"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f1be8ce6-5174-40ab-8cb4-d131d0649d32",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "outdir = \"build/g123-calibration\"\n",
+    "os.makedirs(outdir, exist_ok=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8ee2e373-cafd-40c2-ae84-264fc56b03e3",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "output = {\n",
+    "    \"g123_window_size\": selected_window_size\n",
+    "}\n",
+    "with open(os.path.join(outdir, f\"{cohort_id}.yaml\"), mode=\"w\") as output_file:\n",
+    "    yaml.safe_dump(output, output_file)"
+   ]
+  }
+ ],
+ "metadata": {
+  "celltoolbar": "Tags",
+  "kernelspec": {
+   "display_name": "alimanfoo-selection-atlas",
+   "language": "python",
+   "name": "conda-env-alimanfoo-selection-atlas-py"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/workflow/notebooks/g123-calibration.ipynb
+++ b/workflow/notebooks/g123-calibration.ipynb
@@ -11,7 +11,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "id": "b58ec70a",
    "metadata": {
     "tags": [
@@ -28,7 +28,7 @@
     "sample_sets = \"3.0\"\n",
     "min_cohort_size = 20\n",
     "max_cohort_size = 50\n",
-    "g123_calibration_contig = '3L'\n",
+    "h12_calibration_contig = '3L'\n",
     "use_gcs_cache = False\n",
     "dask_scheduler = \"threads\""
    ]
@@ -43,7 +43,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "id": "a43f9a9b-f202-426f-830e-e430a8f762d7",
    "metadata": {
     "tags": []
@@ -62,24 +62,134 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "id": "f608754e-203a-4bc1-9ba0-aacb02909f08",
    "metadata": {
     "tags": []
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'3.0'"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "sample_sets"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "id": "444cbbad-32b5-4e30-8e91-179b2fadaa6b",
    "metadata": {
     "tags": []
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "application/javascript": "(function(root) {\n  function now() {\n    return new Date();\n  }\n\n  const force = true;\n\n  if (typeof root._bokeh_onload_callbacks === \"undefined\" || force === true) {\n    root._bokeh_onload_callbacks = [];\n    root._bokeh_is_loading = undefined;\n  }\n\nconst JS_MIME_TYPE = 'application/javascript';\n  const HTML_MIME_TYPE = 'text/html';\n  const EXEC_MIME_TYPE = 'application/vnd.bokehjs_exec.v0+json';\n  const CLASS_NAME = 'output_bokeh rendered_html';\n\n  /**\n   * Render data to the DOM node\n   */\n  function render(props, node) {\n    const script = document.createElement(\"script\");\n    node.appendChild(script);\n  }\n\n  /**\n   * Handle when an output is cleared or removed\n   */\n  function handleClearOutput(event, handle) {\n    const cell = handle.cell;\n\n    const id = cell.output_area._bokeh_element_id;\n    const server_id = cell.output_area._bokeh_server_id;\n    // Clean up Bokeh references\n    if (id != null && id in Bokeh.index) {\n      Bokeh.index[id].model.document.clear();\n      delete Bokeh.index[id];\n    }\n\n    if (server_id !== undefined) {\n      // Clean up Bokeh references\n      const cmd_clean = \"from bokeh.io.state import curstate; print(curstate().uuid_to_server['\" + server_id + \"'].get_sessions()[0].document.roots[0]._id)\";\n      cell.notebook.kernel.execute(cmd_clean, {\n        iopub: {\n          output: function(msg) {\n            const id = msg.content.text.trim();\n            if (id in Bokeh.index) {\n              Bokeh.index[id].model.document.clear();\n              delete Bokeh.index[id];\n            }\n          }\n        }\n      });\n      // Destroy server and session\n      const cmd_destroy = \"import bokeh.io.notebook as ion; ion.destroy_server('\" + server_id + \"')\";\n      cell.notebook.kernel.execute(cmd_destroy);\n    }\n  }\n\n  /**\n   * Handle when a new output is added\n   */\n  function handleAddOutput(event, handle) {\n    const output_area = handle.output_area;\n    const output = handle.output;\n\n    // limit handleAddOutput to display_data with EXEC_MIME_TYPE content only\n    if ((output.output_type != \"display_data\") || (!Object.prototype.hasOwnProperty.call(output.data, EXEC_MIME_TYPE))) {\n      return\n    }\n\n    const toinsert = output_area.element.find(\".\" + CLASS_NAME.split(' ')[0]);\n\n    if (output.metadata[EXEC_MIME_TYPE][\"id\"] !== undefined) {\n      toinsert[toinsert.length - 1].firstChild.textContent = output.data[JS_MIME_TYPE];\n      // store reference to embed id on output_area\n      output_area._bokeh_element_id = output.metadata[EXEC_MIME_TYPE][\"id\"];\n    }\n    if (output.metadata[EXEC_MIME_TYPE][\"server_id\"] !== undefined) {\n      const bk_div = document.createElement(\"div\");\n      bk_div.innerHTML = output.data[HTML_MIME_TYPE];\n      const script_attrs = bk_div.children[0].attributes;\n      for (let i = 0; i < script_attrs.length; i++) {\n        toinsert[toinsert.length - 1].firstChild.setAttribute(script_attrs[i].name, script_attrs[i].value);\n        toinsert[toinsert.length - 1].firstChild.textContent = bk_div.children[0].textContent\n      }\n      // store reference to server id on output_area\n      output_area._bokeh_server_id = output.metadata[EXEC_MIME_TYPE][\"server_id\"];\n    }\n  }\n\n  function register_renderer(events, OutputArea) {\n\n    function append_mime(data, metadata, element) {\n      // create a DOM node to render to\n      const toinsert = this.create_output_subarea(\n        metadata,\n        CLASS_NAME,\n        EXEC_MIME_TYPE\n      );\n      this.keyboard_manager.register_events(toinsert);\n      // Render to node\n      const props = {data: data, metadata: metadata[EXEC_MIME_TYPE]};\n      render(props, toinsert[toinsert.length - 1]);\n      element.append(toinsert);\n      return toinsert\n    }\n\n    /* Handle when an output is cleared or removed */\n    events.on('clear_output.CodeCell', handleClearOutput);\n    events.on('delete.Cell', handleClearOutput);\n\n    /* Handle when a new output is added */\n    events.on('output_added.OutputArea', handleAddOutput);\n\n    /**\n     * Register the mime type and append_mime function with output_area\n     */\n    OutputArea.prototype.register_mime_type(EXEC_MIME_TYPE, append_mime, {\n      /* Is output safe? */\n      safe: true,\n      /* Index of renderer in `output_area.display_order` */\n      index: 0\n    });\n  }\n\n  // register the mime type if in Jupyter Notebook environment and previously unregistered\n  if (root.Jupyter !== undefined) {\n    const events = require('base/js/events');\n    const OutputArea = require('notebook/js/outputarea').OutputArea;\n\n    if (OutputArea.prototype.mime_types().indexOf(EXEC_MIME_TYPE) == -1) {\n      register_renderer(events, OutputArea);\n    }\n  }\n  if (typeof (root._bokeh_timeout) === \"undefined\" || force === true) {\n    root._bokeh_timeout = Date.now() + 5000;\n    root._bokeh_failed_load = false;\n  }\n\n  const NB_LOAD_WARNING = {'data': {'text/html':\n     \"<div style='background-color: #fdd'>\\n\"+\n     \"<p>\\n\"+\n     \"BokehJS does not appear to have successfully loaded. If loading BokehJS from CDN, this \\n\"+\n     \"may be due to a slow or bad network connection. Possible fixes:\\n\"+\n     \"</p>\\n\"+\n     \"<ul>\\n\"+\n     \"<li>re-rerun `output_notebook()` to attempt to load from CDN again, or</li>\\n\"+\n     \"<li>use INLINE resources instead, as so:</li>\\n\"+\n     \"</ul>\\n\"+\n     \"<code>\\n\"+\n     \"from bokeh.resources import INLINE\\n\"+\n     \"output_notebook(resources=INLINE)\\n\"+\n     \"</code>\\n\"+\n     \"</div>\"}};\n\n  function display_loaded() {\n    const el = document.getElementById(null);\n    if (el != null) {\n      el.textContent = \"BokehJS is loading...\";\n    }\n    if (root.Bokeh !== undefined) {\n      if (el != null) {\n        el.textContent = \"BokehJS \" + root.Bokeh.version + \" successfully loaded.\";\n      }\n    } else if (Date.now() < root._bokeh_timeout) {\n      setTimeout(display_loaded, 100)\n    }\n  }\n\n  function run_callbacks() {\n    try {\n      root._bokeh_onload_callbacks.forEach(function(callback) {\n        if (callback != null)\n          callback();\n      });\n    } finally {\n      delete root._bokeh_onload_callbacks\n    }\n    console.debug(\"Bokeh: all callbacks have finished\");\n  }\n\n  function load_libs(css_urls, js_urls, callback) {\n    if (css_urls == null) css_urls = [];\n    if (js_urls == null) js_urls = [];\n\n    root._bokeh_onload_callbacks.push(callback);\n    if (root._bokeh_is_loading > 0) {\n      console.debug(\"Bokeh: BokehJS is being loaded, scheduling callback at\", now());\n      return null;\n    }\n    if (js_urls == null || js_urls.length === 0) {\n      run_callbacks();\n      return null;\n    }\n    console.debug(\"Bokeh: BokehJS not loaded, scheduling load and callback at\", now());\n    root._bokeh_is_loading = css_urls.length + js_urls.length;\n\n    function on_load() {\n      root._bokeh_is_loading--;\n      if (root._bokeh_is_loading === 0) {\n        console.debug(\"Bokeh: all BokehJS libraries/stylesheets loaded\");\n        run_callbacks()\n      }\n    }\n\n    function on_error(url) {\n      console.error(\"failed to load \" + url);\n    }\n\n    for (let i = 0; i < css_urls.length; i++) {\n      const url = css_urls[i];\n      const element = document.createElement(\"link\");\n      element.onload = on_load;\n      element.onerror = on_error.bind(null, url);\n      element.rel = \"stylesheet\";\n      element.type = \"text/css\";\n      element.href = url;\n      console.debug(\"Bokeh: injecting link tag for BokehJS stylesheet: \", url);\n      document.body.appendChild(element);\n    }\n\n    for (let i = 0; i < js_urls.length; i++) {\n      const url = js_urls[i];\n      const element = document.createElement('script');\n      element.onload = on_load;\n      element.onerror = on_error.bind(null, url);\n      element.async = false;\n      element.src = url;\n      console.debug(\"Bokeh: injecting script tag for BokehJS library: \", url);\n      document.head.appendChild(element);\n    }\n  };\n\n  function inject_raw_css(css) {\n    const element = document.createElement(\"style\");\n    element.appendChild(document.createTextNode(css));\n    document.body.appendChild(element);\n  }\n\n  const js_urls = [\"https://cdn.bokeh.org/bokeh/release/bokeh-2.4.3.min.js\", \"https://cdn.bokeh.org/bokeh/release/bokeh-gl-2.4.3.min.js\", \"https://cdn.bokeh.org/bokeh/release/bokeh-widgets-2.4.3.min.js\", \"https://cdn.bokeh.org/bokeh/release/bokeh-tables-2.4.3.min.js\", \"https://cdn.bokeh.org/bokeh/release/bokeh-mathjax-2.4.3.min.js\"];\n  const css_urls = [];\n\n  const inline_js = [    function(Bokeh) {\n      Bokeh.set_log_level(\"info\");\n    },\nfunction(Bokeh) {\n    }\n  ];\n\n  function run_inline_js() {\n    if (root.Bokeh !== undefined || force === true) {\n          for (let i = 0; i < inline_js.length; i++) {\n      inline_js[i].call(root, root.Bokeh);\n    }\n} else if (Date.now() < root._bokeh_timeout) {\n      setTimeout(run_inline_js, 100);\n    } else if (!root._bokeh_failed_load) {\n      console.log(\"Bokeh: BokehJS failed to load within specified timeout.\");\n      root._bokeh_failed_load = true;\n    } else if (force !== true) {\n      const cell = $(document.getElementById(null)).parents('.cell').data().cell;\n      cell.output_area.append_execute_result(NB_LOAD_WARNING)\n    }\n  }\n\n  if (root._bokeh_is_loading === 0) {\n    console.debug(\"Bokeh: BokehJS loaded, going straight to plotting\");\n    run_inline_js();\n  } else {\n    load_libs(css_urls, js_urls, function() {\n      console.debug(\"Bokeh: BokehJS plotting callback run at\", now());\n      run_inline_js();\n    });\n  }\n}(window));",
+      "application/vnd.bokehjs_load.v0+json": ""
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "            <table class=\"malariagen-ag3\">\n",
+       "                <thead>\n",
+       "                    <tr>\n",
+       "                        <th style=\"text-align: left\" colspan=\"2\">MalariaGEN Ag3 API client</th>\n",
+       "                    </tr>\n",
+       "                    <tr><td colspan=\"2\" style=\"text-align: left\">\n",
+       "                        Please note that data are subject to terms of use,\n",
+       "                        for more information see <a href=\"https://www.malariagen.net/data\">\n",
+       "                        the MalariaGEN website</a> or contact data@malariagen.net.\n",
+       "                        See also the <a href=\"https://malariagen.github.io/vector-data/ag3/api.html\">Ag3 API docs</a>.\n",
+       "                    </td></tr>\n",
+       "                </thead>\n",
+       "                <tbody>\n",
+       "                    <tr>\n",
+       "                        <th style=\"text-align: left\">\n",
+       "                            Storage URL\n",
+       "                        </th>\n",
+       "                        <td>gs://vo_agam_release/</td>\n",
+       "                    </tr>\n",
+       "                    <tr>\n",
+       "                        <th style=\"text-align: left\">\n",
+       "                            Data releases available\n",
+       "                        </th>\n",
+       "                        <td>3.0</td>\n",
+       "                    </tr>\n",
+       "                    <tr>\n",
+       "                        <th style=\"text-align: left\">\n",
+       "                            Results cache\n",
+       "                        </th>\n",
+       "                        <td>/home/sanj/projects/selection-atlas/malariagen_data_cache</td>\n",
+       "                    </tr>\n",
+       "                    <tr>\n",
+       "                        <th style=\"text-align: left\">\n",
+       "                            Cohorts analysis\n",
+       "                        </th>\n",
+       "                        <td>20230223</td>\n",
+       "                    </tr>\n",
+       "                    <tr>\n",
+       "                        <th style=\"text-align: left\">\n",
+       "                            Species analysis\n",
+       "                        </th>\n",
+       "                        <td>aim_20220528</td>\n",
+       "                    </tr>\n",
+       "                    <tr>\n",
+       "                        <th style=\"text-align: left\">\n",
+       "                            Site filters analysis\n",
+       "                        </th>\n",
+       "                        <td>dt_20200416</td>\n",
+       "                    </tr>\n",
+       "                    <tr>\n",
+       "                        <th style=\"text-align: left\">\n",
+       "                            Software version\n",
+       "                        </th>\n",
+       "                        <td>malariagen_data 7.5.0</td>\n",
+       "                    </tr>\n",
+       "                    <tr>\n",
+       "                        <th style=\"text-align: left\">\n",
+       "                            Client location\n",
+       "                        </th>\n",
+       "                        <td>unknown</td>\n",
+       "                    </tr>\n",
+       "                </tbody>\n",
+       "            </table>\n",
+       "        "
+      ],
+      "text/plain": [
+       "<MalariaGEN Ag3 API client>\n",
+       "Storage URL             : gs://vo_agam_release/\n",
+       "Data releases available : 3.0\n",
+       "Results cache           : /home/sanj/projects/selection-atlas/malariagen_data_cache\n",
+       "Cohorts analysis        : 20230223\n",
+       "Species analysis        : aim_20220528\n",
+       "Site filters analysis   : dt_20200416\n",
+       "Software version        : malariagen_data 7.5.0\n",
+       "Client location         : unknown\n",
+       "---\n",
+       "Please note that data are subject to terms of use,\n",
+       "for more information see https://www.malariagen.net/data\n",
+       "or contact data@malariagen.net. For API documentation see \n",
+       "https://malariagen.github.io/vector-data/ag3/api.html"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "extra_params = dict()\n",
     "if use_gcs_cache:\n",
@@ -97,12 +207,129 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "id": "165f3f10-8301-4b96-bf01-7639efbc47ca",
    "metadata": {
     "tags": []
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>cohort_size</th>\n",
+       "      <th>country</th>\n",
+       "      <th>admin1_iso</th>\n",
+       "      <th>admin1_name</th>\n",
+       "      <th>admin2_name</th>\n",
+       "      <th>taxon</th>\n",
+       "      <th>year</th>\n",
+       "      <th>quarter</th>\n",
+       "      <th>cohort_label</th>\n",
+       "      <th>sample_query</th>\n",
+       "      <th>latitude</th>\n",
+       "      <th>longitude</th>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>cohort_id</th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>ML-2_Kati_colu_2014_Q3</th>\n",
+       "      <td>27</td>\n",
+       "      <td>Mali</td>\n",
+       "      <td>ML-2</td>\n",
+       "      <td>Koulikouro</td>\n",
+       "      <td>Kati</td>\n",
+       "      <td>coluzzii</td>\n",
+       "      <td>2014</td>\n",
+       "      <td>3</td>\n",
+       "      <td>Mali / Kati / coluzzii / 2014 / Q3</td>\n",
+       "      <td>cohort_admin2_quarter == 'ML-2_Kati_colu_2014_...</td>\n",
+       "      <td>12.875556</td>\n",
+       "      <td>-8.137778</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>ML-2_Kati_gamb_2014_Q3</th>\n",
+       "      <td>24</td>\n",
+       "      <td>Mali</td>\n",
+       "      <td>ML-2</td>\n",
+       "      <td>Koulikouro</td>\n",
+       "      <td>Kati</td>\n",
+       "      <td>gambiae</td>\n",
+       "      <td>2014</td>\n",
+       "      <td>3</td>\n",
+       "      <td>Mali / Kati / gambiae / 2014 / Q3</td>\n",
+       "      <td>cohort_admin2_quarter == 'ML-2_Kati_gamb_2014_...</td>\n",
+       "      <td>12.888788</td>\n",
+       "      <td>-8.149091</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                        cohort_size country admin1_iso admin1_name   \n",
+       "cohort_id                                                            \n",
+       "ML-2_Kati_colu_2014_Q3           27    Mali       ML-2  Koulikouro  \\\n",
+       "ML-2_Kati_gamb_2014_Q3           24    Mali       ML-2  Koulikouro   \n",
+       "\n",
+       "                       admin2_name     taxon  year  quarter   \n",
+       "cohort_id                                                     \n",
+       "ML-2_Kati_colu_2014_Q3        Kati  coluzzii  2014        3  \\\n",
+       "ML-2_Kati_gamb_2014_Q3        Kati   gambiae  2014        3   \n",
+       "\n",
+       "                                              cohort_label   \n",
+       "cohort_id                                                    \n",
+       "ML-2_Kati_colu_2014_Q3  Mali / Kati / coluzzii / 2014 / Q3  \\\n",
+       "ML-2_Kati_gamb_2014_Q3   Mali / Kati / gambiae / 2014 / Q3   \n",
+       "\n",
+       "                                                             sample_query   \n",
+       "cohort_id                                                                   \n",
+       "ML-2_Kati_colu_2014_Q3  cohort_admin2_quarter == 'ML-2_Kati_colu_2014_...  \\\n",
+       "ML-2_Kati_gamb_2014_Q3  cohort_admin2_quarter == 'ML-2_Kati_gamb_2014_...   \n",
+       "\n",
+       "                         latitude  longitude  \n",
+       "cohort_id                                     \n",
+       "ML-2_Kati_colu_2014_Q3  12.875556  -8.137778  \n",
+       "ML-2_Kati_gamb_2014_Q3  12.888788  -8.149091  "
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "df_cohorts = pd.read_csv(here() / \"build\" / \"cohorts.csv\").set_index(\"cohort_id\")\n",
     "df_cohorts.head()"
@@ -110,12 +337,37 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "id": "4b8994d6-1f03-4613-9aeb-1dffe9e3c745",
    "metadata": {
     "tags": []
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "ename": "KeyError",
+     "evalue": "'BF-09_Houet_colu_2012_Q3'",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mKeyError\u001b[0m                                  Traceback (most recent call last)",
+      "File \u001b[0;32m~/apps/mambaforge/envs/selection-atlas/lib/python3.10/site-packages/pandas/core/indexes/base.py:3652\u001b[0m, in \u001b[0;36mIndex.get_loc\u001b[0;34m(self, key)\u001b[0m\n\u001b[1;32m   3651\u001b[0m \u001b[39mtry\u001b[39;00m:\n\u001b[0;32m-> 3652\u001b[0m     \u001b[39mreturn\u001b[39;00m \u001b[39mself\u001b[39;49m\u001b[39m.\u001b[39;49m_engine\u001b[39m.\u001b[39;49mget_loc(casted_key)\n\u001b[1;32m   3653\u001b[0m \u001b[39mexcept\u001b[39;00m \u001b[39mKeyError\u001b[39;00m \u001b[39mas\u001b[39;00m err:\n",
+      "File \u001b[0;32m~/apps/mambaforge/envs/selection-atlas/lib/python3.10/site-packages/pandas/_libs/index.pyx:147\u001b[0m, in \u001b[0;36mpandas._libs.index.IndexEngine.get_loc\u001b[0;34m()\u001b[0m\n",
+      "File \u001b[0;32m~/apps/mambaforge/envs/selection-atlas/lib/python3.10/site-packages/pandas/_libs/index.pyx:176\u001b[0m, in \u001b[0;36mpandas._libs.index.IndexEngine.get_loc\u001b[0;34m()\u001b[0m\n",
+      "File \u001b[0;32mpandas/_libs/hashtable_class_helper.pxi:7080\u001b[0m, in \u001b[0;36mpandas._libs.hashtable.PyObjectHashTable.get_item\u001b[0;34m()\u001b[0m\n",
+      "File \u001b[0;32mpandas/_libs/hashtable_class_helper.pxi:7088\u001b[0m, in \u001b[0;36mpandas._libs.hashtable.PyObjectHashTable.get_item\u001b[0;34m()\u001b[0m\n",
+      "\u001b[0;31mKeyError\u001b[0m: 'BF-09_Houet_colu_2012_Q3'",
+      "\nThe above exception was the direct cause of the following exception:\n",
+      "\u001b[0;31mKeyError\u001b[0m                                  Traceback (most recent call last)",
+      "Cell \u001b[0;32mIn[6], line 1\u001b[0m\n\u001b[0;32m----> 1\u001b[0m cohort \u001b[39m=\u001b[39m df_cohorts\u001b[39m.\u001b[39;49mloc[cohort_id]\n\u001b[1;32m      2\u001b[0m cohort\n",
+      "File \u001b[0;32m~/apps/mambaforge/envs/selection-atlas/lib/python3.10/site-packages/pandas/core/indexing.py:1103\u001b[0m, in \u001b[0;36m_LocationIndexer.__getitem__\u001b[0;34m(self, key)\u001b[0m\n\u001b[1;32m   1100\u001b[0m axis \u001b[39m=\u001b[39m \u001b[39mself\u001b[39m\u001b[39m.\u001b[39maxis \u001b[39mor\u001b[39;00m \u001b[39m0\u001b[39m\n\u001b[1;32m   1102\u001b[0m maybe_callable \u001b[39m=\u001b[39m com\u001b[39m.\u001b[39mapply_if_callable(key, \u001b[39mself\u001b[39m\u001b[39m.\u001b[39mobj)\n\u001b[0;32m-> 1103\u001b[0m \u001b[39mreturn\u001b[39;00m \u001b[39mself\u001b[39;49m\u001b[39m.\u001b[39;49m_getitem_axis(maybe_callable, axis\u001b[39m=\u001b[39;49maxis)\n",
+      "File \u001b[0;32m~/apps/mambaforge/envs/selection-atlas/lib/python3.10/site-packages/pandas/core/indexing.py:1343\u001b[0m, in \u001b[0;36m_LocIndexer._getitem_axis\u001b[0;34m(self, key, axis)\u001b[0m\n\u001b[1;32m   1341\u001b[0m \u001b[39m# fall thru to straight lookup\u001b[39;00m\n\u001b[1;32m   1342\u001b[0m \u001b[39mself\u001b[39m\u001b[39m.\u001b[39m_validate_key(key, axis)\n\u001b[0;32m-> 1343\u001b[0m \u001b[39mreturn\u001b[39;00m \u001b[39mself\u001b[39;49m\u001b[39m.\u001b[39;49m_get_label(key, axis\u001b[39m=\u001b[39;49maxis)\n",
+      "File \u001b[0;32m~/apps/mambaforge/envs/selection-atlas/lib/python3.10/site-packages/pandas/core/indexing.py:1293\u001b[0m, in \u001b[0;36m_LocIndexer._get_label\u001b[0;34m(self, label, axis)\u001b[0m\n\u001b[1;32m   1291\u001b[0m \u001b[39mdef\u001b[39;00m \u001b[39m_get_label\u001b[39m(\u001b[39mself\u001b[39m, label, axis: AxisInt):\n\u001b[1;32m   1292\u001b[0m     \u001b[39m# GH#5567 this will fail if the label is not present in the axis.\u001b[39;00m\n\u001b[0;32m-> 1293\u001b[0m     \u001b[39mreturn\u001b[39;00m \u001b[39mself\u001b[39;49m\u001b[39m.\u001b[39;49mobj\u001b[39m.\u001b[39;49mxs(label, axis\u001b[39m=\u001b[39;49maxis)\n",
+      "File \u001b[0;32m~/apps/mambaforge/envs/selection-atlas/lib/python3.10/site-packages/pandas/core/generic.py:4095\u001b[0m, in \u001b[0;36mNDFrame.xs\u001b[0;34m(self, key, axis, level, drop_level)\u001b[0m\n\u001b[1;32m   4093\u001b[0m             new_index \u001b[39m=\u001b[39m index[loc]\n\u001b[1;32m   4094\u001b[0m \u001b[39melse\u001b[39;00m:\n\u001b[0;32m-> 4095\u001b[0m     loc \u001b[39m=\u001b[39m index\u001b[39m.\u001b[39;49mget_loc(key)\n\u001b[1;32m   4097\u001b[0m     \u001b[39mif\u001b[39;00m \u001b[39misinstance\u001b[39m(loc, np\u001b[39m.\u001b[39mndarray):\n\u001b[1;32m   4098\u001b[0m         \u001b[39mif\u001b[39;00m loc\u001b[39m.\u001b[39mdtype \u001b[39m==\u001b[39m np\u001b[39m.\u001b[39mbool_:\n",
+      "File \u001b[0;32m~/apps/mambaforge/envs/selection-atlas/lib/python3.10/site-packages/pandas/core/indexes/base.py:3654\u001b[0m, in \u001b[0;36mIndex.get_loc\u001b[0;34m(self, key)\u001b[0m\n\u001b[1;32m   3652\u001b[0m     \u001b[39mreturn\u001b[39;00m \u001b[39mself\u001b[39m\u001b[39m.\u001b[39m_engine\u001b[39m.\u001b[39mget_loc(casted_key)\n\u001b[1;32m   3653\u001b[0m \u001b[39mexcept\u001b[39;00m \u001b[39mKeyError\u001b[39;00m \u001b[39mas\u001b[39;00m err:\n\u001b[0;32m-> 3654\u001b[0m     \u001b[39mraise\u001b[39;00m \u001b[39mKeyError\u001b[39;00m(key) \u001b[39mfrom\u001b[39;00m \u001b[39merr\u001b[39;00m\n\u001b[1;32m   3655\u001b[0m \u001b[39mexcept\u001b[39;00m \u001b[39mTypeError\u001b[39;00m:\n\u001b[1;32m   3656\u001b[0m     \u001b[39m# If we have a listlike key, _check_indexing_error will raise\u001b[39;00m\n\u001b[1;32m   3657\u001b[0m     \u001b[39m#  InvalidIndexError. Otherwise we fall through and re-raise\u001b[39;00m\n\u001b[1;32m   3658\u001b[0m     \u001b[39m#  the TypeError.\u001b[39;00m\n\u001b[1;32m   3659\u001b[0m     \u001b[39mself\u001b[39m\u001b[39m.\u001b[39m_check_indexing_error(key)\n",
+      "\u001b[0;31mKeyError\u001b[0m: 'BF-09_Houet_colu_2012_Q3'"
+     ]
+    }
+   ],
    "source": [
     "cohort = df_cohorts.loc[cohort_id]\n",
     "cohort"
@@ -172,7 +424,7 @@
    },
    "outputs": [],
    "source": [
-    "contig = g123_calibration_contig\n",
+    "contig = h12_calibration_contig\n",
     "contig"
    ]
   },
@@ -207,7 +459,7 @@
    "outputs": [],
    "source": [
     "ag3.plot_g123_calibration(\n",
-    "    contig=g123_calibration_contig,\n",
+    "    contig=h12_calibration_contig,\n",
     "    site_mask=site_mask,\n",
     "    sample_sets=sample_sets,\n",
     "    sample_query=sample_query,\n",
@@ -227,7 +479,7 @@
    "outputs": [],
    "source": [
     "calibration_runs = ag3.g123_calibration(\n",
-    "    contig=g123_calibration_contig,\n",
+    "    contig=h12_calibration_contig,\n",
     "    site_mask=site_mask,\n",
     "    sample_sets=sample_sets,\n",
     "    sample_query=sample_query,\n",
@@ -298,9 +550,9 @@
  "metadata": {
   "celltoolbar": "Tags",
   "kernelspec": {
-   "display_name": "alimanfoo-selection-atlas",
+   "display_name": "selection-atlas",
    "language": "python",
-   "name": "conda-env-alimanfoo-selection-atlas-py"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -312,7 +564,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.11"
+   "version": "3.10.10"
   }
  },
  "nbformat": 4,

--- a/workflow/notebooks/g123-calibration.ipynb
+++ b/workflow/notebooks/g123-calibration.ipynb
@@ -11,7 +11,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "id": "b58ec70a",
    "metadata": {
     "tags": [
@@ -43,7 +43,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "id": "a43f9a9b-f202-426f-830e-e430a8f762d7",
    "metadata": {
     "tags": []
@@ -62,134 +62,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "id": "f608754e-203a-4bc1-9ba0-aacb02909f08",
    "metadata": {
     "tags": []
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "'3.0'"
-      ]
-     },
-     "execution_count": 3,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "sample_sets"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "id": "444cbbad-32b5-4e30-8e91-179b2fadaa6b",
    "metadata": {
     "tags": []
    },
-   "outputs": [
-    {
-     "data": {
-      "application/javascript": "(function(root) {\n  function now() {\n    return new Date();\n  }\n\n  const force = true;\n\n  if (typeof root._bokeh_onload_callbacks === \"undefined\" || force === true) {\n    root._bokeh_onload_callbacks = [];\n    root._bokeh_is_loading = undefined;\n  }\n\nconst JS_MIME_TYPE = 'application/javascript';\n  const HTML_MIME_TYPE = 'text/html';\n  const EXEC_MIME_TYPE = 'application/vnd.bokehjs_exec.v0+json';\n  const CLASS_NAME = 'output_bokeh rendered_html';\n\n  /**\n   * Render data to the DOM node\n   */\n  function render(props, node) {\n    const script = document.createElement(\"script\");\n    node.appendChild(script);\n  }\n\n  /**\n   * Handle when an output is cleared or removed\n   */\n  function handleClearOutput(event, handle) {\n    const cell = handle.cell;\n\n    const id = cell.output_area._bokeh_element_id;\n    const server_id = cell.output_area._bokeh_server_id;\n    // Clean up Bokeh references\n    if (id != null && id in Bokeh.index) {\n      Bokeh.index[id].model.document.clear();\n      delete Bokeh.index[id];\n    }\n\n    if (server_id !== undefined) {\n      // Clean up Bokeh references\n      const cmd_clean = \"from bokeh.io.state import curstate; print(curstate().uuid_to_server['\" + server_id + \"'].get_sessions()[0].document.roots[0]._id)\";\n      cell.notebook.kernel.execute(cmd_clean, {\n        iopub: {\n          output: function(msg) {\n            const id = msg.content.text.trim();\n            if (id in Bokeh.index) {\n              Bokeh.index[id].model.document.clear();\n              delete Bokeh.index[id];\n            }\n          }\n        }\n      });\n      // Destroy server and session\n      const cmd_destroy = \"import bokeh.io.notebook as ion; ion.destroy_server('\" + server_id + \"')\";\n      cell.notebook.kernel.execute(cmd_destroy);\n    }\n  }\n\n  /**\n   * Handle when a new output is added\n   */\n  function handleAddOutput(event, handle) {\n    const output_area = handle.output_area;\n    const output = handle.output;\n\n    // limit handleAddOutput to display_data with EXEC_MIME_TYPE content only\n    if ((output.output_type != \"display_data\") || (!Object.prototype.hasOwnProperty.call(output.data, EXEC_MIME_TYPE))) {\n      return\n    }\n\n    const toinsert = output_area.element.find(\".\" + CLASS_NAME.split(' ')[0]);\n\n    if (output.metadata[EXEC_MIME_TYPE][\"id\"] !== undefined) {\n      toinsert[toinsert.length - 1].firstChild.textContent = output.data[JS_MIME_TYPE];\n      // store reference to embed id on output_area\n      output_area._bokeh_element_id = output.metadata[EXEC_MIME_TYPE][\"id\"];\n    }\n    if (output.metadata[EXEC_MIME_TYPE][\"server_id\"] !== undefined) {\n      const bk_div = document.createElement(\"div\");\n      bk_div.innerHTML = output.data[HTML_MIME_TYPE];\n      const script_attrs = bk_div.children[0].attributes;\n      for (let i = 0; i < script_attrs.length; i++) {\n        toinsert[toinsert.length - 1].firstChild.setAttribute(script_attrs[i].name, script_attrs[i].value);\n        toinsert[toinsert.length - 1].firstChild.textContent = bk_div.children[0].textContent\n      }\n      // store reference to server id on output_area\n      output_area._bokeh_server_id = output.metadata[EXEC_MIME_TYPE][\"server_id\"];\n    }\n  }\n\n  function register_renderer(events, OutputArea) {\n\n    function append_mime(data, metadata, element) {\n      // create a DOM node to render to\n      const toinsert = this.create_output_subarea(\n        metadata,\n        CLASS_NAME,\n        EXEC_MIME_TYPE\n      );\n      this.keyboard_manager.register_events(toinsert);\n      // Render to node\n      const props = {data: data, metadata: metadata[EXEC_MIME_TYPE]};\n      render(props, toinsert[toinsert.length - 1]);\n      element.append(toinsert);\n      return toinsert\n    }\n\n    /* Handle when an output is cleared or removed */\n    events.on('clear_output.CodeCell', handleClearOutput);\n    events.on('delete.Cell', handleClearOutput);\n\n    /* Handle when a new output is added */\n    events.on('output_added.OutputArea', handleAddOutput);\n\n    /**\n     * Register the mime type and append_mime function with output_area\n     */\n    OutputArea.prototype.register_mime_type(EXEC_MIME_TYPE, append_mime, {\n      /* Is output safe? */\n      safe: true,\n      /* Index of renderer in `output_area.display_order` */\n      index: 0\n    });\n  }\n\n  // register the mime type if in Jupyter Notebook environment and previously unregistered\n  if (root.Jupyter !== undefined) {\n    const events = require('base/js/events');\n    const OutputArea = require('notebook/js/outputarea').OutputArea;\n\n    if (OutputArea.prototype.mime_types().indexOf(EXEC_MIME_TYPE) == -1) {\n      register_renderer(events, OutputArea);\n    }\n  }\n  if (typeof (root._bokeh_timeout) === \"undefined\" || force === true) {\n    root._bokeh_timeout = Date.now() + 5000;\n    root._bokeh_failed_load = false;\n  }\n\n  const NB_LOAD_WARNING = {'data': {'text/html':\n     \"<div style='background-color: #fdd'>\\n\"+\n     \"<p>\\n\"+\n     \"BokehJS does not appear to have successfully loaded. If loading BokehJS from CDN, this \\n\"+\n     \"may be due to a slow or bad network connection. Possible fixes:\\n\"+\n     \"</p>\\n\"+\n     \"<ul>\\n\"+\n     \"<li>re-rerun `output_notebook()` to attempt to load from CDN again, or</li>\\n\"+\n     \"<li>use INLINE resources instead, as so:</li>\\n\"+\n     \"</ul>\\n\"+\n     \"<code>\\n\"+\n     \"from bokeh.resources import INLINE\\n\"+\n     \"output_notebook(resources=INLINE)\\n\"+\n     \"</code>\\n\"+\n     \"</div>\"}};\n\n  function display_loaded() {\n    const el = document.getElementById(null);\n    if (el != null) {\n      el.textContent = \"BokehJS is loading...\";\n    }\n    if (root.Bokeh !== undefined) {\n      if (el != null) {\n        el.textContent = \"BokehJS \" + root.Bokeh.version + \" successfully loaded.\";\n      }\n    } else if (Date.now() < root._bokeh_timeout) {\n      setTimeout(display_loaded, 100)\n    }\n  }\n\n  function run_callbacks() {\n    try {\n      root._bokeh_onload_callbacks.forEach(function(callback) {\n        if (callback != null)\n          callback();\n      });\n    } finally {\n      delete root._bokeh_onload_callbacks\n    }\n    console.debug(\"Bokeh: all callbacks have finished\");\n  }\n\n  function load_libs(css_urls, js_urls, callback) {\n    if (css_urls == null) css_urls = [];\n    if (js_urls == null) js_urls = [];\n\n    root._bokeh_onload_callbacks.push(callback);\n    if (root._bokeh_is_loading > 0) {\n      console.debug(\"Bokeh: BokehJS is being loaded, scheduling callback at\", now());\n      return null;\n    }\n    if (js_urls == null || js_urls.length === 0) {\n      run_callbacks();\n      return null;\n    }\n    console.debug(\"Bokeh: BokehJS not loaded, scheduling load and callback at\", now());\n    root._bokeh_is_loading = css_urls.length + js_urls.length;\n\n    function on_load() {\n      root._bokeh_is_loading--;\n      if (root._bokeh_is_loading === 0) {\n        console.debug(\"Bokeh: all BokehJS libraries/stylesheets loaded\");\n        run_callbacks()\n      }\n    }\n\n    function on_error(url) {\n      console.error(\"failed to load \" + url);\n    }\n\n    for (let i = 0; i < css_urls.length; i++) {\n      const url = css_urls[i];\n      const element = document.createElement(\"link\");\n      element.onload = on_load;\n      element.onerror = on_error.bind(null, url);\n      element.rel = \"stylesheet\";\n      element.type = \"text/css\";\n      element.href = url;\n      console.debug(\"Bokeh: injecting link tag for BokehJS stylesheet: \", url);\n      document.body.appendChild(element);\n    }\n\n    for (let i = 0; i < js_urls.length; i++) {\n      const url = js_urls[i];\n      const element = document.createElement('script');\n      element.onload = on_load;\n      element.onerror = on_error.bind(null, url);\n      element.async = false;\n      element.src = url;\n      console.debug(\"Bokeh: injecting script tag for BokehJS library: \", url);\n      document.head.appendChild(element);\n    }\n  };\n\n  function inject_raw_css(css) {\n    const element = document.createElement(\"style\");\n    element.appendChild(document.createTextNode(css));\n    document.body.appendChild(element);\n  }\n\n  const js_urls = [\"https://cdn.bokeh.org/bokeh/release/bokeh-2.4.3.min.js\", \"https://cdn.bokeh.org/bokeh/release/bokeh-gl-2.4.3.min.js\", \"https://cdn.bokeh.org/bokeh/release/bokeh-widgets-2.4.3.min.js\", \"https://cdn.bokeh.org/bokeh/release/bokeh-tables-2.4.3.min.js\", \"https://cdn.bokeh.org/bokeh/release/bokeh-mathjax-2.4.3.min.js\"];\n  const css_urls = [];\n\n  const inline_js = [    function(Bokeh) {\n      Bokeh.set_log_level(\"info\");\n    },\nfunction(Bokeh) {\n    }\n  ];\n\n  function run_inline_js() {\n    if (root.Bokeh !== undefined || force === true) {\n          for (let i = 0; i < inline_js.length; i++) {\n      inline_js[i].call(root, root.Bokeh);\n    }\n} else if (Date.now() < root._bokeh_timeout) {\n      setTimeout(run_inline_js, 100);\n    } else if (!root._bokeh_failed_load) {\n      console.log(\"Bokeh: BokehJS failed to load within specified timeout.\");\n      root._bokeh_failed_load = true;\n    } else if (force !== true) {\n      const cell = $(document.getElementById(null)).parents('.cell').data().cell;\n      cell.output_area.append_execute_result(NB_LOAD_WARNING)\n    }\n  }\n\n  if (root._bokeh_is_loading === 0) {\n    console.debug(\"Bokeh: BokehJS loaded, going straight to plotting\");\n    run_inline_js();\n  } else {\n    load_libs(css_urls, js_urls, function() {\n      console.debug(\"Bokeh: BokehJS plotting callback run at\", now());\n      run_inline_js();\n    });\n  }\n}(window));",
-      "application/vnd.bokehjs_load.v0+json": ""
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "\n",
-       "            <table class=\"malariagen-ag3\">\n",
-       "                <thead>\n",
-       "                    <tr>\n",
-       "                        <th style=\"text-align: left\" colspan=\"2\">MalariaGEN Ag3 API client</th>\n",
-       "                    </tr>\n",
-       "                    <tr><td colspan=\"2\" style=\"text-align: left\">\n",
-       "                        Please note that data are subject to terms of use,\n",
-       "                        for more information see <a href=\"https://www.malariagen.net/data\">\n",
-       "                        the MalariaGEN website</a> or contact data@malariagen.net.\n",
-       "                        See also the <a href=\"https://malariagen.github.io/vector-data/ag3/api.html\">Ag3 API docs</a>.\n",
-       "                    </td></tr>\n",
-       "                </thead>\n",
-       "                <tbody>\n",
-       "                    <tr>\n",
-       "                        <th style=\"text-align: left\">\n",
-       "                            Storage URL\n",
-       "                        </th>\n",
-       "                        <td>gs://vo_agam_release/</td>\n",
-       "                    </tr>\n",
-       "                    <tr>\n",
-       "                        <th style=\"text-align: left\">\n",
-       "                            Data releases available\n",
-       "                        </th>\n",
-       "                        <td>3.0</td>\n",
-       "                    </tr>\n",
-       "                    <tr>\n",
-       "                        <th style=\"text-align: left\">\n",
-       "                            Results cache\n",
-       "                        </th>\n",
-       "                        <td>/home/sanj/projects/selection-atlas/malariagen_data_cache</td>\n",
-       "                    </tr>\n",
-       "                    <tr>\n",
-       "                        <th style=\"text-align: left\">\n",
-       "                            Cohorts analysis\n",
-       "                        </th>\n",
-       "                        <td>20230223</td>\n",
-       "                    </tr>\n",
-       "                    <tr>\n",
-       "                        <th style=\"text-align: left\">\n",
-       "                            Species analysis\n",
-       "                        </th>\n",
-       "                        <td>aim_20220528</td>\n",
-       "                    </tr>\n",
-       "                    <tr>\n",
-       "                        <th style=\"text-align: left\">\n",
-       "                            Site filters analysis\n",
-       "                        </th>\n",
-       "                        <td>dt_20200416</td>\n",
-       "                    </tr>\n",
-       "                    <tr>\n",
-       "                        <th style=\"text-align: left\">\n",
-       "                            Software version\n",
-       "                        </th>\n",
-       "                        <td>malariagen_data 7.5.0</td>\n",
-       "                    </tr>\n",
-       "                    <tr>\n",
-       "                        <th style=\"text-align: left\">\n",
-       "                            Client location\n",
-       "                        </th>\n",
-       "                        <td>unknown</td>\n",
-       "                    </tr>\n",
-       "                </tbody>\n",
-       "            </table>\n",
-       "        "
-      ],
-      "text/plain": [
-       "<MalariaGEN Ag3 API client>\n",
-       "Storage URL             : gs://vo_agam_release/\n",
-       "Data releases available : 3.0\n",
-       "Results cache           : /home/sanj/projects/selection-atlas/malariagen_data_cache\n",
-       "Cohorts analysis        : 20230223\n",
-       "Species analysis        : aim_20220528\n",
-       "Site filters analysis   : dt_20200416\n",
-       "Software version        : malariagen_data 7.5.0\n",
-       "Client location         : unknown\n",
-       "---\n",
-       "Please note that data are subject to terms of use,\n",
-       "for more information see https://www.malariagen.net/data\n",
-       "or contact data@malariagen.net. For API documentation see \n",
-       "https://malariagen.github.io/vector-data/ag3/api.html"
-      ]
-     },
-     "execution_count": 4,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "extra_params = dict()\n",
     "if use_gcs_cache:\n",
@@ -207,129 +97,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "id": "165f3f10-8301-4b96-bf01-7639efbc47ca",
    "metadata": {
     "tags": []
    },
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>cohort_size</th>\n",
-       "      <th>country</th>\n",
-       "      <th>admin1_iso</th>\n",
-       "      <th>admin1_name</th>\n",
-       "      <th>admin2_name</th>\n",
-       "      <th>taxon</th>\n",
-       "      <th>year</th>\n",
-       "      <th>quarter</th>\n",
-       "      <th>cohort_label</th>\n",
-       "      <th>sample_query</th>\n",
-       "      <th>latitude</th>\n",
-       "      <th>longitude</th>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>cohort_id</th>\n",
-       "      <th></th>\n",
-       "      <th></th>\n",
-       "      <th></th>\n",
-       "      <th></th>\n",
-       "      <th></th>\n",
-       "      <th></th>\n",
-       "      <th></th>\n",
-       "      <th></th>\n",
-       "      <th></th>\n",
-       "      <th></th>\n",
-       "      <th></th>\n",
-       "      <th></th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>ML-2_Kati_colu_2014_Q3</th>\n",
-       "      <td>27</td>\n",
-       "      <td>Mali</td>\n",
-       "      <td>ML-2</td>\n",
-       "      <td>Koulikouro</td>\n",
-       "      <td>Kati</td>\n",
-       "      <td>coluzzii</td>\n",
-       "      <td>2014</td>\n",
-       "      <td>3</td>\n",
-       "      <td>Mali / Kati / coluzzii / 2014 / Q3</td>\n",
-       "      <td>cohort_admin2_quarter == 'ML-2_Kati_colu_2014_...</td>\n",
-       "      <td>12.875556</td>\n",
-       "      <td>-8.137778</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>ML-2_Kati_gamb_2014_Q3</th>\n",
-       "      <td>24</td>\n",
-       "      <td>Mali</td>\n",
-       "      <td>ML-2</td>\n",
-       "      <td>Koulikouro</td>\n",
-       "      <td>Kati</td>\n",
-       "      <td>gambiae</td>\n",
-       "      <td>2014</td>\n",
-       "      <td>3</td>\n",
-       "      <td>Mali / Kati / gambiae / 2014 / Q3</td>\n",
-       "      <td>cohort_admin2_quarter == 'ML-2_Kati_gamb_2014_...</td>\n",
-       "      <td>12.888788</td>\n",
-       "      <td>-8.149091</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "                        cohort_size country admin1_iso admin1_name   \n",
-       "cohort_id                                                            \n",
-       "ML-2_Kati_colu_2014_Q3           27    Mali       ML-2  Koulikouro  \\\n",
-       "ML-2_Kati_gamb_2014_Q3           24    Mali       ML-2  Koulikouro   \n",
-       "\n",
-       "                       admin2_name     taxon  year  quarter   \n",
-       "cohort_id                                                     \n",
-       "ML-2_Kati_colu_2014_Q3        Kati  coluzzii  2014        3  \\\n",
-       "ML-2_Kati_gamb_2014_Q3        Kati   gambiae  2014        3   \n",
-       "\n",
-       "                                              cohort_label   \n",
-       "cohort_id                                                    \n",
-       "ML-2_Kati_colu_2014_Q3  Mali / Kati / coluzzii / 2014 / Q3  \\\n",
-       "ML-2_Kati_gamb_2014_Q3   Mali / Kati / gambiae / 2014 / Q3   \n",
-       "\n",
-       "                                                             sample_query   \n",
-       "cohort_id                                                                   \n",
-       "ML-2_Kati_colu_2014_Q3  cohort_admin2_quarter == 'ML-2_Kati_colu_2014_...  \\\n",
-       "ML-2_Kati_gamb_2014_Q3  cohort_admin2_quarter == 'ML-2_Kati_gamb_2014_...   \n",
-       "\n",
-       "                         latitude  longitude  \n",
-       "cohort_id                                     \n",
-       "ML-2_Kati_colu_2014_Q3  12.875556  -8.137778  \n",
-       "ML-2_Kati_gamb_2014_Q3  12.888788  -8.149091  "
-      ]
-     },
-     "execution_count": 5,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "df_cohorts = pd.read_csv(here() / \"build\" / \"cohorts.csv\").set_index(\"cohort_id\")\n",
     "df_cohorts.head()"
@@ -337,37 +110,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "id": "4b8994d6-1f03-4613-9aeb-1dffe9e3c745",
    "metadata": {
     "tags": []
    },
-   "outputs": [
-    {
-     "ename": "KeyError",
-     "evalue": "'BF-09_Houet_colu_2012_Q3'",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mKeyError\u001b[0m                                  Traceback (most recent call last)",
-      "File \u001b[0;32m~/apps/mambaforge/envs/selection-atlas/lib/python3.10/site-packages/pandas/core/indexes/base.py:3652\u001b[0m, in \u001b[0;36mIndex.get_loc\u001b[0;34m(self, key)\u001b[0m\n\u001b[1;32m   3651\u001b[0m \u001b[39mtry\u001b[39;00m:\n\u001b[0;32m-> 3652\u001b[0m     \u001b[39mreturn\u001b[39;00m \u001b[39mself\u001b[39;49m\u001b[39m.\u001b[39;49m_engine\u001b[39m.\u001b[39;49mget_loc(casted_key)\n\u001b[1;32m   3653\u001b[0m \u001b[39mexcept\u001b[39;00m \u001b[39mKeyError\u001b[39;00m \u001b[39mas\u001b[39;00m err:\n",
-      "File \u001b[0;32m~/apps/mambaforge/envs/selection-atlas/lib/python3.10/site-packages/pandas/_libs/index.pyx:147\u001b[0m, in \u001b[0;36mpandas._libs.index.IndexEngine.get_loc\u001b[0;34m()\u001b[0m\n",
-      "File \u001b[0;32m~/apps/mambaforge/envs/selection-atlas/lib/python3.10/site-packages/pandas/_libs/index.pyx:176\u001b[0m, in \u001b[0;36mpandas._libs.index.IndexEngine.get_loc\u001b[0;34m()\u001b[0m\n",
-      "File \u001b[0;32mpandas/_libs/hashtable_class_helper.pxi:7080\u001b[0m, in \u001b[0;36mpandas._libs.hashtable.PyObjectHashTable.get_item\u001b[0;34m()\u001b[0m\n",
-      "File \u001b[0;32mpandas/_libs/hashtable_class_helper.pxi:7088\u001b[0m, in \u001b[0;36mpandas._libs.hashtable.PyObjectHashTable.get_item\u001b[0;34m()\u001b[0m\n",
-      "\u001b[0;31mKeyError\u001b[0m: 'BF-09_Houet_colu_2012_Q3'",
-      "\nThe above exception was the direct cause of the following exception:\n",
-      "\u001b[0;31mKeyError\u001b[0m                                  Traceback (most recent call last)",
-      "Cell \u001b[0;32mIn[6], line 1\u001b[0m\n\u001b[0;32m----> 1\u001b[0m cohort \u001b[39m=\u001b[39m df_cohorts\u001b[39m.\u001b[39;49mloc[cohort_id]\n\u001b[1;32m      2\u001b[0m cohort\n",
-      "File \u001b[0;32m~/apps/mambaforge/envs/selection-atlas/lib/python3.10/site-packages/pandas/core/indexing.py:1103\u001b[0m, in \u001b[0;36m_LocationIndexer.__getitem__\u001b[0;34m(self, key)\u001b[0m\n\u001b[1;32m   1100\u001b[0m axis \u001b[39m=\u001b[39m \u001b[39mself\u001b[39m\u001b[39m.\u001b[39maxis \u001b[39mor\u001b[39;00m \u001b[39m0\u001b[39m\n\u001b[1;32m   1102\u001b[0m maybe_callable \u001b[39m=\u001b[39m com\u001b[39m.\u001b[39mapply_if_callable(key, \u001b[39mself\u001b[39m\u001b[39m.\u001b[39mobj)\n\u001b[0;32m-> 1103\u001b[0m \u001b[39mreturn\u001b[39;00m \u001b[39mself\u001b[39;49m\u001b[39m.\u001b[39;49m_getitem_axis(maybe_callable, axis\u001b[39m=\u001b[39;49maxis)\n",
-      "File \u001b[0;32m~/apps/mambaforge/envs/selection-atlas/lib/python3.10/site-packages/pandas/core/indexing.py:1343\u001b[0m, in \u001b[0;36m_LocIndexer._getitem_axis\u001b[0;34m(self, key, axis)\u001b[0m\n\u001b[1;32m   1341\u001b[0m \u001b[39m# fall thru to straight lookup\u001b[39;00m\n\u001b[1;32m   1342\u001b[0m \u001b[39mself\u001b[39m\u001b[39m.\u001b[39m_validate_key(key, axis)\n\u001b[0;32m-> 1343\u001b[0m \u001b[39mreturn\u001b[39;00m \u001b[39mself\u001b[39;49m\u001b[39m.\u001b[39;49m_get_label(key, axis\u001b[39m=\u001b[39;49maxis)\n",
-      "File \u001b[0;32m~/apps/mambaforge/envs/selection-atlas/lib/python3.10/site-packages/pandas/core/indexing.py:1293\u001b[0m, in \u001b[0;36m_LocIndexer._get_label\u001b[0;34m(self, label, axis)\u001b[0m\n\u001b[1;32m   1291\u001b[0m \u001b[39mdef\u001b[39;00m \u001b[39m_get_label\u001b[39m(\u001b[39mself\u001b[39m, label, axis: AxisInt):\n\u001b[1;32m   1292\u001b[0m     \u001b[39m# GH#5567 this will fail if the label is not present in the axis.\u001b[39;00m\n\u001b[0;32m-> 1293\u001b[0m     \u001b[39mreturn\u001b[39;00m \u001b[39mself\u001b[39;49m\u001b[39m.\u001b[39;49mobj\u001b[39m.\u001b[39;49mxs(label, axis\u001b[39m=\u001b[39;49maxis)\n",
-      "File \u001b[0;32m~/apps/mambaforge/envs/selection-atlas/lib/python3.10/site-packages/pandas/core/generic.py:4095\u001b[0m, in \u001b[0;36mNDFrame.xs\u001b[0;34m(self, key, axis, level, drop_level)\u001b[0m\n\u001b[1;32m   4093\u001b[0m             new_index \u001b[39m=\u001b[39m index[loc]\n\u001b[1;32m   4094\u001b[0m \u001b[39melse\u001b[39;00m:\n\u001b[0;32m-> 4095\u001b[0m     loc \u001b[39m=\u001b[39m index\u001b[39m.\u001b[39;49mget_loc(key)\n\u001b[1;32m   4097\u001b[0m     \u001b[39mif\u001b[39;00m \u001b[39misinstance\u001b[39m(loc, np\u001b[39m.\u001b[39mndarray):\n\u001b[1;32m   4098\u001b[0m         \u001b[39mif\u001b[39;00m loc\u001b[39m.\u001b[39mdtype \u001b[39m==\u001b[39m np\u001b[39m.\u001b[39mbool_:\n",
-      "File \u001b[0;32m~/apps/mambaforge/envs/selection-atlas/lib/python3.10/site-packages/pandas/core/indexes/base.py:3654\u001b[0m, in \u001b[0;36mIndex.get_loc\u001b[0;34m(self, key)\u001b[0m\n\u001b[1;32m   3652\u001b[0m     \u001b[39mreturn\u001b[39;00m \u001b[39mself\u001b[39m\u001b[39m.\u001b[39m_engine\u001b[39m.\u001b[39mget_loc(casted_key)\n\u001b[1;32m   3653\u001b[0m \u001b[39mexcept\u001b[39;00m \u001b[39mKeyError\u001b[39;00m \u001b[39mas\u001b[39;00m err:\n\u001b[0;32m-> 3654\u001b[0m     \u001b[39mraise\u001b[39;00m \u001b[39mKeyError\u001b[39;00m(key) \u001b[39mfrom\u001b[39;00m \u001b[39merr\u001b[39;00m\n\u001b[1;32m   3655\u001b[0m \u001b[39mexcept\u001b[39;00m \u001b[39mTypeError\u001b[39;00m:\n\u001b[1;32m   3656\u001b[0m     \u001b[39m# If we have a listlike key, _check_indexing_error will raise\u001b[39;00m\n\u001b[1;32m   3657\u001b[0m     \u001b[39m#  InvalidIndexError. Otherwise we fall through and re-raise\u001b[39;00m\n\u001b[1;32m   3658\u001b[0m     \u001b[39m#  the TypeError.\u001b[39;00m\n\u001b[1;32m   3659\u001b[0m     \u001b[39mself\u001b[39m\u001b[39m.\u001b[39m_check_indexing_error(key)\n",
-      "\u001b[0;31mKeyError\u001b[0m: 'BF-09_Houet_colu_2012_Q3'"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "cohort = df_cohorts.loc[cohort_id]\n",
     "cohort"
@@ -461,6 +209,7 @@
     "ag3.plot_g123_calibration(\n",
     "    contig=h12_calibration_contig,\n",
     "    site_mask=site_mask,\n",
+    "    sites=site_mask,\n",
     "    sample_sets=sample_sets,\n",
     "    sample_query=sample_query,\n",
     "    min_cohort_size=min_cohort_size,\n",
@@ -481,6 +230,7 @@
     "calibration_runs = ag3.g123_calibration(\n",
     "    contig=h12_calibration_contig,\n",
     "    site_mask=site_mask,\n",
+    "    sites=site_mask,\n",
     "    sample_sets=sample_sets,\n",
     "    sample_query=sample_query,\n",
     "    min_cohort_size=min_cohort_size,\n",

--- a/workflow/notebooks/g123-gwss.ipynb
+++ b/workflow/notebooks/g123-gwss.ipynb
@@ -1,0 +1,218 @@
+{
+ "cells": [
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "id": "7b236ee1-7932-43a9-bb4f-078b2bd0e6b6",
+   "metadata": {},
+   "source": [
+    "# G123 genome-wide selection scans"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3abe056c",
+   "metadata": {
+    "tags": [
+     "parameters"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "# Notebook parameters. Values here are for development only and \n",
+    "# will be overridden when running via snakemake and papermill.\n",
+    "cohort_id = 'BF-09_Houet_gamb_2012_Q3'\n",
+    "cohorts_analysis = \"20230223\"\n",
+    "contigs = [\"3L\"]\n",
+    "sample_sets = \"3.0\"\n",
+    "min_cohort_size = 20\n",
+    "max_cohort_size = 50\n",
+    "use_gcs_cache = False\n",
+    "dask_scheduler = \"threads\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a4dc68dd-56d9-4b60-b168-641f6339a458",
+   "metadata": {},
+   "source": [
+    "## Setup"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "df2f18c0",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "import yaml\n",
+    "import pandas as pd\n",
+    "import malariagen_data\n",
+    "from pyprojroot import here\n",
+    "import numpy as np\n",
+    "import os\n",
+    "import dask\n",
+    "dask.config.set(scheduler=dask_scheduler);"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a076d3f0-4e54-4041-9f03-d7be6eb2cf1a",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "sample_sets"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "96d1d6ac",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "extra_params = dict()\n",
+    "if use_gcs_cache:\n",
+    "    extra_params[\"url\"] = \"simplecache::gs://vo_agam_release\"\n",
+    "    extra_params[\"simplecache\"] = dict(cache_storage=(here() / \"gcs_cache\").as_posix())\n",
+    "\n",
+    "ag3 = malariagen_data.Ag3(\n",
+    "    # pin the version of the cohorts analysis for reproducibility\n",
+    "    cohorts_analysis=cohorts_analysis,\n",
+    "    results_cache=(here() / \"malariagen_data_cache\").as_posix(),\n",
+    "    **extra_params,\n",
+    ")\n",
+    "ag3"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4de3e8dd",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# load window sizes \n",
+    "calibration_dir = \"build/g123-calibration\"\n",
+    "with open(here() / calibration_dir / f\"{cohort_id}.yaml\") as calibration_file:\n",
+    "    calibration_params = yaml.safe_load(calibration_file)\n",
+    "window_size = calibration_params[\"g123_window_size\"]\n",
+    "window_size"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "53d5999d",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# load cohorts to find sample query \n",
+    "df_cohorts = pd.read_csv(here() / \"build\" / \"final_cohorts.csv\").set_index(\"cohort_id\")\n",
+    "cohort = df_cohorts.loc[cohort_id]\n",
+    "cohort"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "739344b6",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "sample_query = cohort.sample_query\n",
+    "sample_query"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ec39fbce",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "if cohort.taxon == 'arabiensis':\n",
+    "    site_mask = 'arab'\n",
+    "else:\n",
+    "    site_mask = 'gamb_colu'\n",
+    "site_mask"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "181c2a43-7e70-467e-85af-bd3113c24513",
+   "metadata": {},
+   "source": [
+    "## Run GWSS"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "394f5afb",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "for contig in contigs:\n",
+    "    print(f\"running {contig}\")\n",
+    "    ag3.plot_g123_gwss(\n",
+    "        contig=contig, \n",
+    "        window_size=window_size, \n",
+    "        site_mask=site_mask, \n",
+    "        sample_sets=sample_sets,\n",
+    "        sample_query=sample_query, \n",
+    "        min_cohort_size=min_cohort_size,\n",
+    "        max_cohort_size=max_cohort_size,\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "034515ca-3d70-4364-a8a4-5273d02c9dda",
+   "metadata": {},
+   "source": [
+    "N.B., results of the selection scans will be automatically saved into the malariagen_data results cache."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "selection-atlas",
+   "language": "python",
+   "name": "selection-atlas"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/workflow/notebooks/ihs-gwss.ipynb
+++ b/workflow/notebooks/ihs-gwss.ipynb
@@ -1,0 +1,223 @@
+{
+ "cells": [
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "id": "7b236ee1-7932-43a9-bb4f-078b2bd0e6b6",
+   "metadata": {},
+   "source": [
+    "# iHS genome-wide selection scans"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3abe056c",
+   "metadata": {
+    "tags": [
+     "parameters"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "# Notebook parameters. Values here are for development only and \n",
+    "# will be overridden when running via snakemake and papermill.\n",
+    "cohort_id = 'BF-09_Houet_gamb_2012_Q3'\n",
+    "cohorts_analysis = \"20230223\"\n",
+    "contigs = [\"3L\"]\n",
+    "sample_sets = \"3.0\"\n",
+    "min_cohort_size = 20\n",
+    "max_cohort_size = 50\n",
+    "use_gcs_cache = False\n",
+    "dask_scheduler = \"threads\""
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "id": "a4dc68dd-56d9-4b60-b168-641f6339a458",
+   "metadata": {},
+   "source": [
+    "## Setup"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "df2f18c0",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "import yaml\n",
+    "import pandas as pd\n",
+    "import malariagen_data\n",
+    "from pyprojroot import here\n",
+    "import numpy as np\n",
+    "import os\n",
+    "import dask\n",
+    "dask.config.set(scheduler=dask_scheduler);"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a076d3f0-4e54-4041-9f03-d7be6eb2cf1a",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "sample_sets"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "96d1d6ac",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "extra_params = dict()\n",
+    "if use_gcs_cache:\n",
+    "    extra_params[\"url\"] = \"simplecache::gs://vo_agam_release\"\n",
+    "    extra_params[\"simplecache\"] = dict(cache_storage=(here() / \"gcs_cache\").as_posix())\n",
+    "\n",
+    "ag3 = malariagen_data.Ag3(\n",
+    "    # pin the version of the cohorts analysis for reproducibility\n",
+    "    cohorts_analysis=cohorts_analysis,\n",
+    "    results_cache=(here() / \"malariagen_data_cache\").as_posix(),\n",
+    "    **extra_params,\n",
+    ")\n",
+    "ag3"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4de3e8dd",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# load window sizes \n",
+    "calibration_dir = \"build/h12-calibration\"\n",
+    "with open(here() / calibration_dir / f\"{cohort_id}.yaml\") as calibration_file:\n",
+    "    calibration_params = yaml.safe_load(calibration_file)\n",
+    "window_size = calibration_params[\"h12_window_size\"]\n",
+    "window_size"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "53d5999d",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# load cohorts to find sample query \n",
+    "df_cohorts = pd.read_csv(here() / \"build\" / \"final_cohorts.csv\").set_index(\"cohort_id\")\n",
+    "cohort = df_cohorts.loc[cohort_id]\n",
+    "cohort"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "739344b6",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "sample_query = cohort.sample_query\n",
+    "sample_query"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ec39fbce",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "if cohort.taxon == 'arabiensis':\n",
+    "    phasing_analysis = 'arab'\n",
+    "else:\n",
+    "    phasing_analysis = 'gamb_colu'\n",
+    "phasing_analysis\n",
+    "\n",
+    "ihs_window_size = 100"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "id": "181c2a43-7e70-467e-85af-bd3113c24513",
+   "metadata": {},
+   "source": [
+    "## Run GWSS"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "394f5afb",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "for contig in contigs:\n",
+    "    print(f\"running {contig}\")\n",
+    "    ag3.plot_ihs_gwss(\n",
+    "        contig=contig, \n",
+    "        window_size=ihs_window_size, \n",
+    "        analysis=phasing_analysis, \n",
+    "        sample_sets=sample_sets,\n",
+    "        sample_query=sample_query, \n",
+    "        min_cohort_size=min_cohort_size,\n",
+    "        max_cohort_size=max_cohort_size,\n",
+    "    )"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "id": "034515ca-3d70-4364-a8a4-5273d02c9dda",
+   "metadata": {},
+   "source": [
+    "N.B., results of the selection scans will be automatically saved into the malariagen_data results cache."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "selection-atlas",
+   "language": "python",
+   "name": "selection-atlas"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -29,17 +29,28 @@ def get_selection_atlas_outputs(wildcards):
     df = gpd.read_file(checkpoints.geolocate_cohorts.get().output.cohorts_geojson)
 
     # define paths to output files
-    cal_paths = "build/h12-calibration/" + df['cohort_id'] + ".yaml"
-    cal_notebook_paths = "build/notebooks/h12-calibration-" + df['cohort_id'] + ".ipynb"
-    gwss_paths = "build/notebooks/h12-gwss-" + df['cohort_id'] + ".ipynb"
-    signal_paths = expand("build/h12-signal-detection/{cohort}_{contig}.csv", cohort=df['cohort_id'], contig=chromosomes)
+    h12_cal_paths = "build/h12-calibration/" + df['cohort_id'] + ".yaml"
+    h12_cal_notebook_paths = "build/notebooks/h12-calibration-" + df['cohort_id'] + ".ipynb"
+    h12_gwss_paths = "build/notebooks/h12-gwss-" + df['cohort_id'] + ".ipynb"
+    h12_signal_paths = expand("build/h12-signal-detection/{cohort}_{contig}.csv", cohort=df['cohort_id'], contig=chromosomes)
+
+    # define paths to output files
+    g123_cal_paths = "build/g123-calibration/" + df['cohort_id'] + ".yaml"
+    g123_cal_notebook_paths = "build/notebooks/g123-calibration-" + df['cohort_id'] + ".ipynb"
+    g123_gwss_paths = "build/notebooks/g123-gwss-" + df['cohort_id'] + ".ipynb"
+    
+    ihs_gwss_paths = "build/notebooks/ihs-gwss-" + df['cohort_id'] + ".ipynb"
 
     # add output files to list
     wanted_outputs = []
-    wanted_outputs.extend(cal_paths)
-    wanted_outputs.extend(cal_notebook_paths)
-    wanted_outputs.extend(gwss_paths)
-    wanted_outputs.extend(signal_paths)
+    wanted_outputs.extend(h12_cal_paths)
+    wanted_outputs.extend(h12_cal_notebook_paths)
+    wanted_outputs.extend(h12_gwss_paths)
+    wanted_outputs.extend(h12_signal_paths)
+    wanted_outputs.extend(g123_cal_paths)
+    wanted_outputs.extend(g123_cal_notebook_paths)
+    wanted_outputs.extend(g123_gwss_paths)
+    wanted_outputs.extend(ihs_gwss_paths)
     
     return wanted_outputs
 

--- a/workflow/rules/gwss.smk
+++ b/workflow/rules/gwss.smk
@@ -64,18 +64,64 @@ rule h12_signal_detection:
          -p contig {wildcards.contig} -f {input.config} 2> {log}
         """
 
-# rule ihs:
-#     input:
-#         template = f"{workflow.basedir}/notebooks/ihs-gwss.ipynb",
-#         cohorts = "build/final_cohorts.csv",
-#         config = configpath    
-#     output:
-#         output_nb="build/notebooks/ihs-gwss-{cohort}.ipynb"
-#     log:
-#         "logs/ihs_gwss/{cohort}.log"
-#     conda:
-#         f"{workflow.basedir}/../environment.yml"
-#     shell:
-#         """
-#         papermill {input.nb} {output.nb} -k selection-atlas -p cohort_id {wildcards.cohort} -p window_size {params.window_size}
-#         """
+
+rule g123_calibration:
+    """
+    Calibrate the window size for each cohort.
+    """
+    input:
+        nb=f"{workflow.basedir}/notebooks/g123-calibration.ipynb",
+        config = configpath
+    output:
+        nb="build/notebooks/g123-calibration-{cohort}.ipynb",
+        yaml = "build/g123-calibration/{cohort}.yaml"
+    log:
+        "logs/g123_calibration/{cohort}.log"
+    conda:
+        f"{workflow.basedir}/../environment.yml"
+    shell:
+        """
+        papermill {input.nb} {output.nb} -k selection-atlas \
+        -p cohort_id {wildcards.cohort} -f {input.config} 2> {log}
+        """
+
+rule g123_gwss:
+    """
+    Run the g123 GWSS
+    """
+    input:
+        template = f"{workflow.basedir}/notebooks/g123-gwss.ipynb",
+        window_size = "build/g123-calibration/{cohort}.yaml",
+        cohorts = "build/final_cohorts.csv",
+        config = configpath
+    output:
+        nb="build/notebooks/g123-gwss-{cohort}.ipynb"
+    log:
+        "logs/g123_gwss/{cohort}.log"
+    conda:
+        f"{workflow.basedir}/../environment.yml"
+    shell:
+        """
+        papermill {input.template} {output.nb} -k selection-atlas -p cohort_id {wildcards.cohort} \
+        -f {input.config} 2> {log}
+        """
+
+rule ihs_gwss:
+    """
+    Run the iHS GWSS
+    """
+    input:
+        template = f"{workflow.basedir}/notebooks/ihs-gwss.ipynb",
+        cohorts = "build/final_cohorts.csv",
+        config = configpath
+    output:
+        nb="build/notebooks/ihs-gwss-{cohort}.ipynb"
+    log:
+        "logs/ihs_gwss/{cohort}.log"
+    conda:
+        f"{workflow.basedir}/../environment.yml"
+    shell:
+        """
+        papermill {input.template} {output.nb} -k selection-atlas -p cohort_id {wildcards.cohort} \
+        -f {input.config} 2> {log}
+        """

--- a/workflow/rules/site.smk
+++ b/workflow/rules/site.smk
@@ -87,8 +87,9 @@ rule cohort_pages:
         nb = f"{workflow.basedir}/notebooks/cohort-page.ipynb",
         cohorts_geojson = rules.geolocate_cohorts.output.cohorts_geojson,
         output_h12="build/notebooks/h12-gwss-{cohort}.ipynb",
+        output_g123="build/notebooks/g123-gwss-{cohort}.ipynb",
+        output_ihs="build/notebooks/ihs-gwss-{cohort}.ipynb",
         config = configpath,
-        #output_ihs="build/notebooks/ihs-gwss-{cohort}.ipynb",
         signals = expand("build/h12-signal-detection/{{cohort}}_{contig}.csv", contig=chromosomes),
     output:
         nb = "build/notebooks/cohort/{cohort}.ipynb",


### PR DESCRIPTION
Addresses #33 and #34. Prior to this PR, we did not have explicit notebooks for G123 and iHS, they would just be requested when the final cohorts page was built. We were also using the window size from H12 calibration for G123, rather than running a proper calibration for G123 itself. 

This PR adds notebooks for G123-GWSS and G123-calibration, and iHS-GWSS. They follow the same structure as the H12 equivalents. iHS parameters are still set to the defaults in malariagen_data. 