### PR TITLE
Upgrade to malariagen_data 7.10.0 to get support for bokeh webgl backend

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -7,39 +7,37 @@ dependencies:
   - _openmp_mutex=4.5=2_gnu
   - accessible-pygments=0.0.4=pyhd8ed1ab_0
   - aioeasywebdav=2.4.0=pyha770c72_0
-  - aiofiles=22.1.0=pyhd8ed1ab_0
   - aiohttp=3.7.4.post0=py310h6acc77f_1
-  - aiosqlite=0.19.0=pyhd8ed1ab_0
   - alabaster=0.7.13=pyhd8ed1ab_0
   - alsa-lib=1.2.8=h166bdaf_0
   - amply=0.1.5=pyhd8ed1ab_0
   - ansiwrap=0.8.4=py_0
-  - anyio=3.6.2=pyhd8ed1ab_0
+  - anyio=3.7.0=pyhd8ed1ab_1
   - appdirs=1.4.4=pyh9f0ad1d_0
   - argcomplete=3.0.8=pyhd8ed1ab_0
   - argon2-cffi=21.3.0=pyhd8ed1ab_0
   - argon2-cffi-bindings=21.2.0=py310h5764c6d_3
-  - arrow-cpp=11.0.0=ha770c72_16_cpu
   - asciitree=0.3.3=py_2
   - asteval=0.9.29=pyhd8ed1ab_0
   - asttokens=2.2.1=pyhd8ed1ab_0
+  - async-lru=2.0.2=pyhd8ed1ab_0
   - async-timeout=3.0.1=py_1000
   - attmap=0.13.2=pyhd8ed1ab_0
   - attr=2.5.1=h166bdaf_1
   - attrs=21.4.0=pyhd8ed1ab_0
-  - aws-c-auth=0.6.26=h2c7c9e7_6
-  - aws-c-cal=0.5.26=h71eb795_0
-  - aws-c-common=0.8.17=hd590300_0
-  - aws-c-compression=0.2.16=h4f47f36_6
-  - aws-c-event-stream=0.2.20=h69ce273_6
-  - aws-c-http=0.7.7=h7b8353a_3
-  - aws-c-io=0.13.21=hcccde9c_3
-  - aws-c-mqtt=0.8.6=h3a1964a_15
-  - aws-c-s3=0.2.8=h0933b68_4
-  - aws-c-sdkutils=0.1.9=h4f47f36_1
-  - aws-checksums=0.1.14=h4f47f36_6
-  - aws-crt-cpp=0.19.9=h85076f6_5
-  - aws-sdk-cpp=1.10.57=hf40e4db_10
+  - aws-c-auth=0.6.27=he072965_1
+  - aws-c-cal=0.5.26=hf677bf3_1
+  - aws-c-common=0.8.19=hd590300_0
+  - aws-c-compression=0.2.16=hbad4bc6_7
+  - aws-c-event-stream=0.2.20=hb4b372c_7
+  - aws-c-http=0.7.7=h2632f9a_4
+  - aws-c-io=0.13.21=h9fef7b8_5
+  - aws-c-mqtt=0.8.11=h2282364_1
+  - aws-c-s3=0.3.0=hcb5a9b2_2
+  - aws-c-sdkutils=0.1.9=hbad4bc6_2
+  - aws-checksums=0.1.14=hbad4bc6_7
+  - aws-crt-cpp=0.20.2=he0fdcb3_0
+  - aws-sdk-cpp=1.10.57=h059227d_13
   - babel=2.12.1=pyhd8ed1ab_1
   - backcall=0.2.0=pyh9f0ad1d_0
   - backports=1.0=pyhd8ed1ab_3
@@ -50,24 +48,24 @@ dependencies:
   - black=23.3.0=py310hff52083_1
   - bleach=6.0.0=pyhd8ed1ab_0
   - blinker=1.6.2=pyhd8ed1ab_0
-  - blosc=1.21.3=hafa529b_0
-  - bokeh=2.4.3=pyhd8ed1ab_3
+  - blosc=1.21.4=h0f2a231_0
+  - bokeh=3.1.1=pyhd8ed1ab_0
   - boltons=23.0.0=pyhd8ed1ab_0
   - boost-cpp=1.78.0=h6582d0a_3
   - boto=2.49.0=py_0
-  - boto3=1.26.132=pyhd8ed1ab_0
-  - botocore=1.29.132=pyhd8ed1ab_0
+  - boto3=1.26.144=pyhd8ed1ab_0
+  - botocore=1.29.145=pyhd8ed1ab_0
   - branca=0.6.0=pyhd8ed1ab_0
   - brotli=1.0.9=h166bdaf_8
   - brotli-bin=1.0.9=h166bdaf_8
   - brotlipy=0.7.0=py310h5764c6d_1005
   - bzip2=1.0.8=h7f98852_4
-  - c-ares=1.18.1=h7f98852_0
+  - c-ares=1.19.1=hd590300_0
   - ca-certificates=2023.5.7=hbcca054_0
   - cached-property=1.5.2=hd8ed1ab_1
   - cached_property=1.5.2=pyha770c72_1
   - cachetools=5.3.0=pyhd8ed1ab_0
-  - cairo=1.16.0=h35add3b_1015
+  - cairo=1.16.0=hbbf8b49_1016
   - certifi=2023.5.7=pyhd8ed1ab_0
   - cffi=1.15.1=py310h255011f_3
   - cfitsio=4.2.0=hd9d235c_0
@@ -87,26 +85,26 @@ dependencies:
   - comm=0.1.3=pyhd8ed1ab_0
   - conda=23.3.1=py310hff52083_0
   - conda-package-handling=2.0.2=pyh38be061_0
-  - conda-package-streaming=0.7.0=pyhd8ed1ab_1
+  - conda-package-streaming=0.8.0=pyhd8ed1ab_0
   - configargparse=1.5.3=pyhd8ed1ab_0
   - connection_pool=0.0.3=pyhd3deb0d_0
   - contourpy=1.0.7=py310hdf3cbec_0
   - crcmod=1.7=py310h5764c6d_1009
-  - cryptography=40.0.2=py310h34c0648_0
-  - curl=8.0.1=h588be90_0
+  - cryptography=41.0.0=py310h75e40e8_0
+  - curl=8.1.2=h409715c_0
   - cycler=0.11.0=pyhd8ed1ab_0
   - cytoolz=0.12.0=py310h5764c6d_1
-  - dask=2023.4.1=pyhd8ed1ab_0
-  - dask-core=2023.4.1=pyhd8ed1ab_0
+  - dask=2023.5.1=pyhd8ed1ab_0
+  - dask-core=2023.5.1=pyhd8ed1ab_0
   - dataclasses=0.8=pyhc8e2a94_3
   - datrie=0.8.2=py310h5764c6d_6
   - dbus=1.13.6=h5008d03_3
   - debugpy=1.6.7=py310heca2aa9_0
   - decorator=5.1.1=pyhd8ed1ab_0
   - defusedxml=0.7.1=pyhd8ed1ab_0
-  - distributed=2023.4.1=pyhd8ed1ab_0
+  - distributed=2023.5.1=pyhd8ed1ab_0
   - docutils=0.17.1=py310hff52083_3
-  - dpath=2.1.5=pyha770c72_1
+  - dpath=2.1.6=pyha770c72_0
   - dropbox=11.36.0=pyhd8ed1ab_0
   - entrypoints=0.4=pyhd8ed1ab_0
   - exceptiongroup=1.1.1=pyhd8ed1ab_0
@@ -115,8 +113,8 @@ dependencies:
   - fasteners=0.17.3=pyhd8ed1ab_0
   - filechunkio=1.8=py_2
   - filelock=3.12.0=pyhd8ed1ab_0
-  - fiona=1.9.3=py310ha325b7b_0
-  - flit-core=3.8.0=pyhd8ed1ab_0
+  - fiona=1.9.4=py310h111440e_0
+  - flit-core=3.9.0=pyhd8ed1ab_0
   - fmt=9.1.0=h924138e_0
   - folium=0.14.0=pyhd8ed1ab_0
   - font-ttf-dejavu-sans-mono=2.37=hab24e00_0
@@ -132,9 +130,9 @@ dependencies:
   - fsspec=2023.5.0=pyh1a96a4e_0
   - ftputil=5.0.4=pyhd8ed1ab_0
   - future=0.18.3=pyhd8ed1ab_0
-  - gcs-oauth2-boto-plugin=3.0=pyhd8ed1ab_1
+  - gcs-oauth2-boto-plugin=3.0=pyhd8ed1ab_0
   - gcsfs=2023.5.0=pyhd8ed1ab_0
-  - gdal=3.6.4=py310hf0ca374_2
+  - gdal=3.7.0=py310h52aca19_1
   - geopandas=0.13.0=pyhd8ed1ab_0
   - geopandas-base=0.13.0=pyha770c72_0
   - geos=3.11.2=hcb278e6_0
@@ -144,13 +142,13 @@ dependencies:
   - giflib=5.2.1=h0b41bf4_3
   - gitdb=4.0.10=pyhd8ed1ab_0
   - gitpython=3.1.31=pyhd8ed1ab_0
-  - glib=2.76.2=hfc55251_0
-  - glib-tools=2.76.2=hfc55251_0
+  - glib=2.76.3=hfc55251_0
+  - glib-tools=2.76.3=hfc55251_0
   - glog=0.6.0=h6f12383_0
   - google-api-core=2.11.0=pyhd8ed1ab_0
-  - google-api-python-client=2.86.0=pyhd8ed1ab_0
+  - google-api-python-client=2.88.0=pyhd8ed1ab_0
   - google-apitools=0.5.32=pyhd8ed1ab_0
-  - google-auth=2.18.0=pyh1a96a4e_0
+  - google-auth=2.19.0=pyh1a96a4e_0
   - google-auth-httplib2=0.1.0=pyhd8ed1ab_1
   - google-auth-oauthlib=1.0.0=pyhd8ed1ab_0
   - google-cloud-core=2.3.2=pyhd8ed1ab_0
@@ -160,13 +158,13 @@ dependencies:
   - google-resumable-media=2.5.0=pyhd8ed1ab_0
   - googleapis-common-protos=1.57.1=pyhd8ed1ab_0
   - graphite2=1.3.13=h58526e2_1001
-  - greenlet=2.0.2=py310heca2aa9_0
-  - grpcio=1.54.2=py310heca2aa9_0
-  - gst-plugins-base=1.22.0=h4243ec0_2
-  - gstreamer=1.22.0=h25f0c4b_2
-  - gsutil=5.23=pyhd8ed1ab_0
+  - greenlet=2.0.2=py310hc6cd4ac_1
+  - grpcio=1.54.2=py310heca2aa9_2
+  - gst-plugins-base=1.22.3=h938bd60_1
+  - gstreamer=1.22.3=h977cf35_1
+  - gsutil=5.24=pyhd8ed1ab_0
   - h5py=3.8.0=nompi_py310ha66b2ad_101
-  - harfbuzz=6.0.0=h3ff4399_1
+  - harfbuzz=7.3.0=hdb3a94d_0
   - hdf4=4.2.15=h501b40f_6
   - hdf5=1.14.0=nompi_hb72d44e_103
   - httplib2=0.20.4=pyhd8ed1ab_0
@@ -177,10 +175,9 @@ dependencies:
   - importlib_metadata=6.6.0=hd8ed1ab_0
   - importlib_resources=5.12.0=pyhd8ed1ab_0
   - iniconfig=2.0.0=pyhd8ed1ab_0
-  - ipykernel=6.23.0=pyh210e3f2_0
+  - ipykernel=6.23.1=pyh210e3f2_0
   - ipyleaflet=0.17.2=pyhd8ed1ab_0
   - ipython=8.13.2=pyh41d4057_0
-  - ipython_genutils=0.2.0=py_1
   - ipywidgets=8.0.6=pyhd8ed1ab_0
   - iso3166=2.1.1=pyhd8ed1ab_0
   - jedi=0.18.2=pyhd8ed1ab_0
@@ -194,19 +191,17 @@ dependencies:
   - jsonschema=4.17.3=pyhd8ed1ab_0
   - jupyter-book=0.15.1=pyhd8ed1ab_0
   - jupyter-cache=0.6.1=pyhd8ed1ab_0
+  - jupyter-lsp=2.2.0=pyhd8ed1ab_0
   - jupyter_client=8.2.0=pyhd8ed1ab_0
   - jupyter_core=5.3.0=py310hff52083_0
   - jupyter_events=0.6.3=pyhd8ed1ab_0
-  - jupyter_server=2.5.0=pyhd8ed1ab_0
-  - jupyter_server_fileid=0.9.0=pyhd8ed1ab_0
+  - jupyter_server=2.6.0=pyhd8ed1ab_0
   - jupyter_server_terminals=0.4.4=pyhd8ed1ab_1
-  - jupyter_server_ydoc=0.8.0=pyhd8ed1ab_0
-  - jupyter_ydoc=0.2.3=pyhd8ed1ab_0
-  - jupyterlab=3.6.3=pyhd8ed1ab_0
+  - jupyterlab=4.0.1=pyhd8ed1ab_0
   - jupyterlab_pygments=0.2.2=pyhd8ed1ab_0
   - jupyterlab_server=2.22.1=pyhd8ed1ab_0
-  - jupyterlab_widgets=3.0.7=pyhd8ed1ab_0
-  - kealib=1.5.0=he7a6254_1
+  - jupyterlab_widgets=3.0.7=pyhd8ed1ab_1
+  - kealib=1.5.1=h3845be2_3
   - keyutils=1.6.1=h166bdaf_0
   - kiwisolver=1.4.4=py310hbf28c38_1
   - krb5=1.20.1=h81ceb04_0
@@ -215,48 +210,48 @@ dependencies:
   - lcms2=2.15=haa2dc70_1
   - ld_impl_linux-64=2.40=h41732ed_0
   - lerc=4.0.0=h27087fc_0
-  - libabseil=20230125.0=cxx17_hcb278e6_1
+  - libabseil=20230125.2=cxx17_h59595ed_2
   - libaec=1.0.6=hcb278e6_1
-  - libarchive=3.6.2=h3d51595_0
-  - libarrow=11.0.0=h8dc56a0_16_cpu
+  - libarchive=3.6.2=h039dbb9_1
+  - libarrow=12.0.0=h96638e8_5_cpu
   - libblas=3.9.0=16_linux64_openblas
   - libbrotlicommon=1.0.9=h166bdaf_8
   - libbrotlidec=1.0.9=h166bdaf_8
   - libbrotlienc=1.0.9=h166bdaf_8
   - libcap=2.67=he9d0100_0
   - libcblas=3.9.0=16_linux64_openblas
-  - libclang=16.0.3=default_h83cc7fd_0
-  - libclang13=16.0.3=default_hd781213_0
+  - libclang=15.0.7=default_h7634d5b_2
+  - libclang13=15.0.7=default_h9986a30_2
   - libcrc32c=1.1.2=h9c3ff4c_0
   - libcups=2.3.3=h36d4200_3
-  - libcurl=8.0.1=h588be90_0
+  - libcurl=8.1.2=h409715c_0
   - libdeflate=1.18=h0b41bf4_0
   - libedit=3.1.20191231=he28a2e2_2
   - libev=4.33=h516909a_1
-  - libevent=2.1.10=h28343ad_4
+  - libevent=2.1.12=h3358134_0
   - libexpat=2.5.0=hcb278e6_1
   - libffi=3.4.2=h7f98852_5
   - libflac=1.4.2=h27087fc_0
   - libgcc-ng=12.2.0=h65d4601_19
   - libgcrypt=1.10.1=h166bdaf_0
-  - libgdal=3.6.4=hada8d5e_2
+  - libgdal=3.7.0=h9f4e061_1
   - libgfortran-ng=12.2.0=h69a702a_19
   - libgfortran5=12.2.0=h337968e_19
-  - libglib=2.76.2=hebfc3b9_0
+  - libglib=2.76.3=hebfc3b9_0
   - libgomp=12.2.0=h65d4601_19
-  - libgoogle-cloud=2.8.0=hac9eb74_2
+  - libgoogle-cloud=2.10.1=hac9eb74_1
   - libgpg-error=1.46=h620e276_0
-  - libgrpc=1.54.2=hcf146ea_0
+  - libgrpc=1.54.2=hb20ce57_2
   - libiconv=1.17=h166bdaf_0
   - libjpeg-turbo=2.1.5.1=h0b41bf4_0
   - libkml=1.3.0=h37653c0_1015
   - liblapack=3.9.0=16_linux64_openblas
   - liblapacke=3.9.0=16_linux64_openblas
-  - libllvm11=11.1.0=he0ac6c6_5
-  - libllvm16=16.0.3=hbf9e925_1
+  - libllvm14=14.0.6=hcd5def8_2
+  - libllvm15=15.0.7=h5cf9203_2
   - libmamba=1.4.2=hcea66bb_0
   - libmambapy=1.4.2=py310h1428755_0
-  - libnetcdf=4.9.2=nompi_hdf9a29f_104
+  - libnetcdf=4.9.2=nompi_h0f3d0bb_105
   - libnghttp2=1.52.0=h61bc06f_0
   - libnsl=2.0.0=h7f98852_0
   - libnuma=2.0.16=h0b41bf4_1
@@ -264,31 +259,31 @@ dependencies:
   - libopenblas=0.3.21=pthreads_h78a6416_3
   - libopus=1.3.1=h7f98852_1
   - libpng=1.6.39=h753d276_0
-  - libpq=15.3=hbcd7760_0
+  - libpq=15.3=hbcd7760_1
   - libprotobuf=3.21.12=h3eb15da_0
   - librttopo=1.1.0=h0d5128d_13
   - libsndfile=1.2.0=hb75c966_0
   - libsodium=1.0.18=h36c2ea0_1
   - libsolv=0.7.23=h3eb15da_0
   - libspatialindex=1.9.3=h9c3ff4c_4
-  - libspatialite=5.0.1=h7d1ca68_25
-  - libsqlite=3.41.2=h2797004_1
+  - libspatialite=5.0.1=hb46c372_26
+  - libsqlite=3.42.0=h2797004_0
   - libssh2=1.10.0=hf14f497_3
   - libstdcxx-ng=12.2.0=h46fd767_19
   - libsystemd0=253=h8c4010b_1
-  - libthrift=0.18.1=h5e4af38_0
+  - libthrift=0.18.1=h8fd135c_1
   - libtiff=4.5.0=ha587672_6
   - libutf8proc=2.8.0=h166bdaf_0
   - libuuid=2.38.1=h0b41bf4_0
   - libvorbis=1.3.7=h9c3ff4c_0
   - libwebp-base=1.3.0=h0b41bf4_0
-  - libxcb=1.13=h7f98852_1004
-  - libxkbcommon=1.5.0=h79f4944_1
-  - libxml2=2.10.4=hfdac1af_0
+  - libxcb=1.15=h0b41bf4_0
+  - libxkbcommon=1.5.0=h5d7e998_3
+  - libxml2=2.11.4=h0d562d8_0
   - libzip=1.9.2=hc929e4a_1
   - libzlib=1.2.13=h166bdaf_4
   - linkify-it-py=2.0.0=pyhd8ed1ab_0
-  - llvmlite=0.39.1=py310h58363a5_1
+  - llvmlite=0.40.0=py310h1b8f574_0
   - lmfit=1.2.1=pyhd8ed1ab_0
   - locket=1.0.0=pyhd8ed1ab_0
   - logmuse=0.2.6=pyh8c360ce_0
@@ -309,43 +304,38 @@ dependencies:
   - mpg123=1.31.3=hcb278e6_0
   - msgpack-python=1.0.5=py310hdf3cbec_0
   - multidict=6.0.4=py310h1fa729e_0
-  - munch=2.5.0=py_0
+  - munch=3.0.0=pyhd8ed1ab_0
   - munkres=1.1.4=pyh9f0ad1d_0
   - mypy_extensions=1.0.0=pyha770c72_0
   - mysql-common=8.0.32=hf1915f5_2
   - mysql-libs=8.0.32=hca2cd23_2
   - myst-nb=0.17.2=pyhd8ed1ab_0
   - myst-parser=0.18.1=pyhd8ed1ab_0
-  - nbclassic=1.0.0=pyhb4ecaf3_1
   - nbclient=0.7.4=pyhd8ed1ab_0
-  - nbconvert=7.4.0=pyhd8ed1ab_0
   - nbconvert-core=7.4.0=pyhd8ed1ab_0
-  - nbconvert-pandoc=7.4.0=pyhd8ed1ab_0
-  - nbformat=5.8.0=pyhd8ed1ab_0
+  - nbformat=5.9.0=pyhd8ed1ab_0
   - ncurses=6.3=h27087fc_1
   - nest-asyncio=1.5.6=pyhd8ed1ab_0
   - networkx=3.1=pyhd8ed1ab_0
   - nomkl=1.0=h5ca1d4c_0
-  - notebook=6.5.4=pyha770c72_0
   - notebook-shim=0.2.3=pyhd8ed1ab_0
   - nspr=4.35=h27087fc_0
   - nss=3.89=he45b914_0
-  - numba=0.56.4=py310h0e39c9b_1
+  - numba=0.57.0=py310h0f6aa51_1
   - numcodecs=0.11.0=py310heca2aa9_1
   - numexpr=2.8.4=py310h690d005_100
-  - numpy=1.23.5=py310h53a5b5f_0
+  - numpy=1.24.3=py310ha4c1d20_0
   - oauth2client=4.1.3=py_0
   - oauthlib=3.2.2=pyhd8ed1ab_0
   - openjpeg=2.5.0=hfec8fc6_2
-  - openssl=3.1.0=hd590300_3
+  - openssl=3.1.1=hd590300_1
   - orc=1.8.3=hfdbbad2_0
+  - overrides=7.3.1=pyhd8ed1ab_0
   - packaging=23.1=pyhd8ed1ab_0
-  - pandas=2.0.1=py310h7cbd5c2_1
-  - pandoc=2.19.2=h32600fe_2
+  - pandas=2.0.2=py310h7cbd5c2_0
   - pandocfilters=1.5.0=pyhd8ed1ab_0
   - papermill=2.3.4=pyhd8ed1ab_0
-  - paramiko=3.1.0=pyhd8ed1ab_0
-  - parquet-cpp=1.5.1=2
+  - paramiko=3.2.0=pyhd8ed1ab_0
   - parso=0.8.3=pyhd8ed1ab_0
   - partd=1.4.0=pyhd8ed1ab_0
   - pathspec=0.11.1=pyhd8ed1ab_0
@@ -354,12 +344,12 @@ dependencies:
   - peppy=0.35.5=pyhd8ed1ab_0
   - pexpect=4.8.0=pyh1a96a4e_2
   - pickleshare=0.7.5=py_1003
-  - pillow=9.5.0=py310h065c6d2_0
+  - pillow=9.5.0=py310h582fbeb_1
   - pip=23.1.2=pyhd8ed1ab_0
   - pixman=0.40.0=h36c2ea0_0
   - pkgutil-resolve-name=1.3.10=pyhd8ed1ab_0
   - plac=1.3.5=pyhd8ed1ab_0
-  - platformdirs=3.5.0=pyhd8ed1ab_0
+  - platformdirs=3.5.1=pyhd8ed1ab_0
   - plotly=5.14.1=pyhd8ed1ab_0
   - pluggy=1.0.0=pyhd8ed1ab_5
   - ply=3.11=py_1
@@ -367,10 +357,10 @@ dependencies:
   - pooch=1.7.0=pyha770c72_3
   - poppler=23.05.0=hd18248d_1
   - poppler-data=0.4.12=hd8ed1ab_0
-  - postgresql=15.3=h814edd5_0
+  - postgresql=15.3=hd458b1d_1
   - prettytable=3.7.0=pyhd8ed1ab_0
   - proj=9.2.0=h8ffa02c_0
-  - prometheus_client=0.16.0=pyhd8ed1ab_0
+  - prometheus_client=0.17.0=pyhd8ed1ab_0
   - prompt-toolkit=3.0.38=pyha770c72_0
   - prompt_toolkit=3.0.38=hd8ed1ab_0
   - protobuf=4.21.12=py310heca2aa9_0
@@ -378,9 +368,9 @@ dependencies:
   - pthread-stubs=0.4=h36c2ea0_1001
   - ptyprocess=0.7.0=pyhd3deb0d_0
   - pulp=2.7.0=py310hff52083_0
-  - pulseaudio-client=16.1=h5195f5e_3
+  - pulseaudio-client=16.1=hb77b528_4
   - pure_eval=0.2.2=pyhd8ed1ab_0
-  - pyarrow=11.0.0=py310he6bfd7f_16_cpu
+  - pyarrow=12.0.0=py310he6bfd7f_5_cpu
   - pyasn1=0.4.8=py_0
   - pyasn1-modules=0.2.7=py_0
   - pybind11-abi=4=hd8ed1ab_3
@@ -392,7 +382,7 @@ dependencies:
   - pygments=2.15.1=pyhd8ed1ab_0
   - pyjwt=2.7.0=pyhd8ed1ab_0
   - pynacl=1.5.0=py310h5764c6d_2
-  - pyopenssl=23.1.1=pyhd8ed1ab_0
+  - pyopenssl=23.2.0=pyhd8ed1ab_1
   - pyparsing=3.0.9=pyhd8ed1ab_0
   - pyproj=3.5.0=py310hb814896_1
   - pyprojroot=0.3.0=pyhd8ed1ab_0
@@ -404,36 +394,37 @@ dependencies:
   - pytest=7.3.1=pyhd8ed1ab_0
   - python=3.10.11=he550d4f_0_cpython
   - python-dateutil=2.8.2=pyhd8ed1ab_0
-  - python-fastjsonschema=2.16.3=pyhd8ed1ab_0
-  - python-irodsclient=1.1.6=pyhd8ed1ab_0
+  - python-fastjsonschema=2.17.1=pyhd8ed1ab_0
+  - python-irodsclient=1.1.8=pyhd8ed1ab_0
   - python-json-logger=2.0.7=pyhd8ed1ab_0
   - python-tzdata=2023.3=pyhd8ed1ab_0
   - python_abi=3.10=3_cp310
   - pytz=2023.3=pyhd8ed1ab_0
   - pyu2f=0.1.5=pyhd8ed1ab_0
   - pyyaml=6.0=py310h5764c6d_5
-  - pyzmq=25.0.2=py310h059b190_0
-  - qt-main=5.15.8=h5c52f38_10
-  - re2=2023.02.02=hcb278e6_0
+  - pyzmq=25.1.0=py310h5bbb5d0_0
+  - qt-main=5.15.8=h01ceb2d_13
+  - rdma-core=28.9=h59595ed_1
+  - re2=2023.03.02=h8c504da_0
   - readline=8.2=h8228510_1
   - reproc=14.2.4=h0b41bf4_0
   - reproc-cpp=14.2.4=hcb278e6_0
-  - requests=2.29.0=pyhd8ed1ab_0
+  - requests=2.31.0=pyhd8ed1ab_0
   - requests-oauthlib=1.3.1=pyhd8ed1ab_0
   - reretry=0.11.8=pyhd8ed1ab_0
   - retry_decorator=1.1.1=pyh9f0ad1d_0
   - rfc3339-validator=0.1.4=pyhd8ed1ab_0
   - rfc3986-validator=0.1.1=pyh9f0ad1d_0
-  - rich=13.3.5=pyhd8ed1ab_0
-  - rsa=4.7.2=pyh44b312d_0
+  - rich=13.4.1=pyhd8ed1ab_0
+  - rsa=4.9=pyhd8ed1ab_0
   - rtree=1.0.1=py310hbdcdc62_1
-  - ruamel.yaml=0.17.26=py310h2372a71_0
+  - ruamel.yaml=0.17.31=py310h2372a71_0
   - ruamel.yaml.clib=0.2.7=py310h1fa729e_1
-  - s2n=1.3.42=h3358134_0
+  - s2n=1.3.44=h06160fa_0
   - s3transfer=0.6.1=pyhd8ed1ab_0
   - scikit-allel=1.3.5=py310hb5077e9_1
-  - scikit-learn=1.2.2=py310h41b6a48_1
-  - scipy=1.10.1=py310h8deb116_2
+  - scikit-learn=1.2.2=py310hf7d194e_2
+  - scipy=1.10.1=py310ha4c1d20_3
   - seaborn=0.12.2=hd8ed1ab_0
   - seaborn-base=0.12.2=pyhd8ed1ab_0
   - send2trash=1.8.2=pyh41d4057_0
@@ -445,11 +436,12 @@ dependencies:
   - slacker=0.14.0=py_0
   - smart_open=6.3.0=pyhd8ed1ab_1
   - smmap=3.0.5=pyh44b312d_0
-  - snakemake=7.25.3=hdfd78af_0
-  - snakemake-minimal=7.25.3=pyhdfd78af_0
+  - snakemake=7.26.0=hdfd78af_0
+  - snakemake-minimal=7.26.0=pyhdfd78af_0
   - snappy=1.1.10=h9fff704_0
   - sniffio=1.3.0=pyhd8ed1ab_0
   - snowballstemmer=2.2.0=pyhd8ed1ab_0
+  - socksipy-branch=1.01=pyh9f0ad1d_0
   - sortedcontainers=2.4.0=pyhd8ed1ab_0
   - soupsieve=2.3.2.post1=pyhd8ed1ab_0
   - sphinx=4.5.0=pyh6c4a22f_0
@@ -469,8 +461,8 @@ dependencies:
   - sphinxcontrib-jsmath=1.0.1=py_0
   - sphinxcontrib-qthelp=1.0.3=py_0
   - sphinxcontrib-serializinghtml=1.1.5=pyhd8ed1ab_2
-  - sqlalchemy=2.0.13=py310h2372a71_0
-  - sqlite=3.41.2=h2c6b66d_1
+  - sqlalchemy=2.0.15=py310h2372a71_0
+  - sqlite=3.42.0=h2c6b66d_0
   - stack_data=0.6.2=pyhd8ed1ab_0
   - statsmodels=0.14.0=py310h278f3c1_1
   - stone=3.3.1=pyhd8ed1ab_0
@@ -489,17 +481,18 @@ dependencies:
   - tomli=2.0.1=pyhd8ed1ab_0
   - toolz=0.12.0=pyhd8ed1ab_0
   - toposort=1.10=pyhd8ed1ab_0
-  - tornado=6.3=py310h1fa729e_0
+  - tornado=6.3.2=py310h2372a71_0
   - tqdm=4.65.0=pyhd8ed1ab_1
   - traitlets=5.9.0=pyhd8ed1ab_0
   - traittypes=0.2.1=pyh9f0ad1d_2
-  - typing-extensions=4.5.0=hd8ed1ab_0
-  - typing_extensions=4.5.0=pyha770c72_0
+  - typing-extensions=4.6.2=hd8ed1ab_0
+  - typing_extensions=4.6.2=pyha770c72_0
+  - typing_utils=0.1.0=pyhd8ed1ab_0
   - tzcode=2023c=h0b41bf4_0
   - tzdata=2023c=h71feb2d_0
   - ubiquerg=0.6.2=pyhd8ed1ab_0
   - uc-micro-py=1.0.1=pyhd8ed1ab_0
-  - ucx=1.14.0=h3484d09_2
+  - ucx=1.14.1=hf587318_2
   - uncertainties=3.1.7=pyhd8ed1ab_0
   - unicodedata2=15.0.0=py310h5764c6d_0
   - uritemplate=4.1.1=pyhd8ed1ab_0
@@ -507,23 +500,23 @@ dependencies:
   - veracitools=0.1.3=py_0
   - wcwidth=0.2.6=pyhd8ed1ab_0
   - webencodings=0.5.1=py_1
-  - websocket-client=1.5.1=pyhd8ed1ab_0
+  - websocket-client=1.5.2=pyhd8ed1ab_0
   - wheel=0.40.0=pyhd8ed1ab_0
   - widgetsnbextension=4.0.7=pyhd8ed1ab_0
   - wrapt=1.15.0=py310h1fa729e_0
-  - xarray=2023.4.2=pyhd8ed1ab_0
-  - xcb-util=0.4.0=h516909a_0
-  - xcb-util-image=0.4.0=h166bdaf_0
-  - xcb-util-keysyms=0.4.0=h516909a_0
-  - xcb-util-renderutil=0.3.9=h166bdaf_0
-  - xcb-util-wm=0.4.1=h516909a_0
+  - xarray=2023.5.0=pyhd8ed1ab_0
+  - xcb-util=0.4.0=hd590300_1
+  - xcb-util-image=0.4.0=h8ee46fc_1
+  - xcb-util-keysyms=0.4.0=h8ee46fc_1
+  - xcb-util-renderutil=0.3.9=hd590300_1
+  - xcb-util-wm=0.4.1=h8ee46fc_1
   - xerces-c=3.2.4=h8d71039_2
   - xkeyboard-config=2.38=h0b41bf4_0
   - xorg-kbproto=1.0.7=h7f98852_1002
-  - xorg-libice=1.0.10=h7f98852_0
-  - xorg-libsm=1.2.3=hd9c2040_1000
-  - xorg-libx11=1.8.4=h0b41bf4_0
-  - xorg-libxau=1.0.9=h7f98852_0
+  - xorg-libice=1.1.1=hd590300_0
+  - xorg-libsm=1.2.4=h7391055_0
+  - xorg-libx11=1.8.4=h8ee46fc_1
+  - xorg-libxau=1.0.11=hd590300_0
   - xorg-libxdmcp=1.1.3=h7f98852_0
   - xorg-libxext=1.3.4=h0b41bf4_2
   - xorg-libxrender=0.9.10=h7f98852_1003
@@ -531,14 +524,12 @@ dependencies:
   - xorg-xextproto=7.3.0=h0b41bf4_1003
   - xorg-xf86vidmodeproto=2.3.1=h7f98852_1002
   - xorg-xproto=7.0.31=h7f98852_1007
-  - xyzservices=2023.2.0=pyhd8ed1ab_0
+  - xyzservices=2023.5.0=pyhd8ed1ab_1
   - xz=5.2.6=h166bdaf_0
-  - y-py=0.5.9=py310h4426083_0
   - yaml=0.2.5=h7f98852_2
   - yaml-cpp=0.7.0=h27087fc_2
-  - yarl=1.9.1=py310h2372a71_0
-  - ypy-websocket=0.8.2=pyhd8ed1ab_0
-  - yte=1.5.1=py310hff52083_1
+  - yarl=1.9.2=py310h2372a71_0
+  - yte=1.5.1=pyha770c72_2
   - zarr=2.14.2=pyhd8ed1ab_0
   - zeromq=4.3.4=h9c3ff4c_1
   - zict=3.0.0=pyhd8ed1ab_0
@@ -548,19 +539,22 @@ dependencies:
   - zstd=1.5.2=h3eb15da_6
   - pip:
       - ansi2html==1.8.0
-      - dash==2.9.3
+      - dash==2.10.2
       - dash-core-components==2.0.0
       - dash-cytoscape==0.3.0
       - dash-html-components==2.0.0
       - dash-table==5.0.0
-      - flask==2.3.2
-      - igv-notebook==0.5.1
+      - flask==2.2.5
+      - igv-notebook==0.5.2
       - importlib-metadata==4.13.0
       - ipinfo==4.4.2
       - itsdangerous==2.1.2
       - jupyter-dash==0.4.2
-      - malariagen-data==7.6.0
-      - numpydoc-decorator==2.0.0
+      - malariagen-data==7.10.0
+      - numpydoc-decorator==2.1.0
+      - orjson==3.9.0
+      - protopunica==0.14.8
       - retrying==1.3.4
-      - werkzeug==2.3.4
+      - typeguard==4.0.0
+      - werkzeug==2.2.3
 prefix: /home/aliman/mambaforge/envs/selection-atlas

--- a/requirements.yml
+++ b/requirements.yml
@@ -3,7 +3,7 @@ channels:
     - conda-forge
     - bioconda
 dependencies:
-    - python=3.11
+    - python=3.10
     - numpy
     - snakemake
     - papermill

--- a/requirements.yml
+++ b/requirements.yml
@@ -3,8 +3,8 @@ channels:
     - conda-forge
     - bioconda
 dependencies:
-    - python=3.10
-    - numpy<1.24
+    - python=3.11
+    - numpy
     - snakemake
     - papermill
     - scipy
@@ -19,7 +19,7 @@ dependencies:
     - BioPython
     - gsutil
     - scikit-allel
-    - bokeh<3.0
+    - bokeh>=3.1
     - statsmodels
     - ipyleaflet
     - tqdm
@@ -34,4 +34,4 @@ dependencies:
     - pip
     - pip:
           - jsonschema>=3.1.0
-          - malariagen_data>=7.6.0
+          - malariagen_data>=7.10.0

--- a/workflow/notebooks/chromosome-page.ipynb
+++ b/workflow/notebooks/chromosome-page.ipynb
@@ -198,7 +198,7 @@
     "\n",
     "# make figure \n",
     "fig1 = bkplt.figure(title='Selection signals',\n",
-    "                  plot_width=900, plot_height=200 + (10 * max(df.level)), \n",
+    "                  width=900, height=200 + (10 * max(df.level)), \n",
     "                  tools=\"tap,xpan,xzoom_in,xzoom_out,xwheel_zoom,reset\".split() + [hover],\n",
     "                  toolbar_location='above', active_drag='xpan', active_scroll='xwheel_zoom')\n",
     "\n",


### PR DESCRIPTION
Upgrade the requirements and pinned environment in order to get malariagen_data 7.10.0, which has support for using webgl backend for bokeh plots, which we want to see if it helps with #51.

Also includes a small fix to the chromosome page notebook because bokeh is upgraded too, hope that doesn't cause nasty conflicts with work in #52.