### PR TITLE
cohort page - overlay signals on H12 plot

### DIFF
--- a/workflow/notebooks/chromosome-page.ipynb
+++ b/workflow/notebooks/chromosome-page.ipynb
@@ -229,7 +229,7 @@
     "fig1.quad(bottom='bottom', top='top', left='focus_start', right='focus_stop', \n",
     "          source=source, color=\"red\", alpha=.7, line_width=2)\n",
     "\n",
-    "glyph = bkmod.MultiLine(xs='center_xs', ys='center_ys', line_color='red', line_width=2, line_alpha=0.8))\n",
+    "glyph = bkmod.MultiLine(xs='center_xs', ys='center_ys', line_color='red', line_width=2, line_alpha=0.8)\n",
     "fig1.add_glyph(source, glyph)\n",
     "\n",
     "fig1.patches(xs='right_xs', ys='right_ys', source=source, color=\"color\", alpha=.7, line_width=2, legend_field='taxon')\n",

--- a/workflow/notebooks/chromosome-page.ipynb
+++ b/workflow/notebooks/chromosome-page.ipynb
@@ -14,7 +14,7 @@
    "source": [
     "# Notebook parameters. Values here are for development only and \n",
     "# will be overridden when running via snakemake and papermill.\n",
-    "contig = '3L'\n",
+    "contig = '3RL'\n",
     "cohorts_analysis = '20230223'\n",
     "use_gcs_cache = False\n",
     "dask_scheduler = \"threads\""
@@ -56,7 +56,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "658506c0",
    "metadata": {},
@@ -168,6 +167,16 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "eb841e51",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "id": "b99bfaa6",
    "metadata": {
     "tags": [
@@ -179,11 +188,14 @@
     "df = df_signals.reset_index()\n",
     "\n",
     "# set up triangle shapes for bokeh patches glyphs\n",
-    "left_xs = [np.array([row.span2_pstart, row.focus_pstart, row.focus_pstart])  for idx, row in df.iterrows()]\n",
+    "left_xs = [np.array([row.span2_pstart, row.focus_pstart, row.focus_pstart]) for idx, row in df.iterrows()]\n",
     "left_ys = [np.array([row.level + .1, row.level, row.level + .2])  for idx, row in df.iterrows()]\n",
     "\n",
     "right_xs = [np.array([row.focus_pstop, row.focus_pstop, row.span2_pstop])  for idx, row in df.iterrows()]\n",
     "right_ys = [np.array([row.level, row.level + .2, row.level + .1]) for idx, row in df.iterrows()]\n",
+    "\n",
+    "center_xs = [np.array([row.pcenter, row.pcenter]) for idx, row in df.iterrows()]\n",
+    "center_ys = [np.array([row.level, row.level + .2]) for idx, row in df.iterrows()]\n",
     "\n",
     "source = bkmod.ColumnDataSource(data={\n",
     "    'cohort': df.cohort_id,\n",
@@ -199,6 +211,8 @@
     "    'left_ys':left_ys,\n",
     "    'right_xs':right_xs,\n",
     "    'right_ys':right_ys,\n",
+    "    'center_xs': center_xs,\n",
+    "    'center_ys': center_ys,\n",
     "    'bottom': df.level,\n",
     "    'mid': df.level + .5,\n",
     "    'top': df.level + .2,\n",
@@ -223,6 +237,9 @@
     "\n",
     "fig1.quad(bottom='bottom', top='top', left='focus_start', right='focus_stop', \n",
     "          source=source, color=\"red\", alpha=.7, line_width=2)\n",
+    "\n",
+    "glyph = bkmod.MultiLine(xs='center_xs', ys='center_ys', line_color='red', line_width=2)\n",
+    "fig1.add_glyph(source, glyph)\n",
     "\n",
     "fig1.patches(xs='right_xs', ys='right_ys', source=source, color=\"color\", alpha=.7, line_width=2, legend_field='taxon')\n",
     "\n",

--- a/workflow/notebooks/chromosome-page.ipynb
+++ b/workflow/notebooks/chromosome-page.ipynb
@@ -56,6 +56,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "658506c0",
    "metadata": {},
@@ -162,16 +163,6 @@
     "\n",
     "df_signals = df_signals.sort_values(by='span2_pstart')\n",
     "df_signals['level'] = stack_overlaps(df_signals, 'span2_pstart', 'span2_pstop')"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "eb841e51",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "df"
    ]
   },
   {

--- a/workflow/notebooks/chromosome-page.ipynb
+++ b/workflow/notebooks/chromosome-page.ipynb
@@ -229,7 +229,7 @@
     "fig1.quad(bottom='bottom', top='top', left='focus_start', right='focus_stop', \n",
     "          source=source, color=\"red\", alpha=.7, line_width=2)\n",
     "\n",
-    "glyph = bkmod.MultiLine(xs='center_xs', ys='center_ys', line_color='red', line_width=2)\n",
+    "glyph = bkmod.MultiLine(xs='center_xs', ys='center_ys', line_color='red', line_width=2, line_alpha=0.8))\n",
     "fig1.add_glyph(source, glyph)\n",
     "\n",
     "fig1.patches(xs='right_xs', ys='right_ys', source=source, color=\"color\", alpha=.7, line_width=2, legend_field='taxon')\n",

--- a/workflow/notebooks/cohort-page.ipynb
+++ b/workflow/notebooks/cohort-page.ipynb
@@ -363,7 +363,7 @@
     "          source=source, color=\"gray\", alpha=.1, line_width=1)\n",
     "    quad2 = fig1.quad(bottom='bottom', top='top', left='focus_start', right='focus_stop', \n",
     "          source=source, color=\"red\", alpha=.4)\n",
-    "    glyph = bkmod.MultiLine(xs='center_xs', ys='center_ys', line_color='red', line_width=2)\n",
+    "    glyph = bkmod.MultiLine(xs='center_xs', ys='center_ys', line_color='red', line_width=2, line_alpha=0.8)\n",
     "    fig1.add_glyph(source, glyph)\n",
     "    \n",
     "    hover = bkmod.HoverTool(tooltips=[\n",

--- a/workflow/notebooks/cohort-page.ipynb
+++ b/workflow/notebooks/cohort-page.ipynb
@@ -324,6 +324,10 @@
     "\n",
     "    sample_query = cohort[\"sample_query\"]\n",
     "    df = df_signals.query(\"contig == @contig\")\n",
+    "    \n",
+    "    center_xs = [np.array([row.pcenter, row.pcenter]) for idx, row in df.iterrows()]\n",
+    "    center_ys = [np.array([row.level, row.level + .2]) for idx, row in df.iterrows()]\n",
+    "\n",
     "    source = bkmod.ColumnDataSource(data={\n",
     "        'cohort': df.cohort_id,\n",
     "        'chromosome': df.contig,\n",
@@ -332,6 +336,8 @@
     "        'peak_stop': df.span2_pstop,\n",
     "        'focus_start': df.focus_pstart,\n",
     "        'focus_stop': df.focus_pstop,    \n",
+    "        'center_xs': center_xs,\n",
+    "        'center_ys': center_ys,\n",
     "        'bottom': df.bottom ,\n",
     "        'top': df.top,\n",
     "        })\n",
@@ -354,6 +360,8 @@
     "          source=source, color=\"gray\", alpha=.1, line_width=1)\n",
     "    quad2 = fig1.quad(bottom='bottom', top='top', left='focus_start', right='focus_stop', \n",
     "          source=source, color=\"red\", alpha=.4)\n",
+    "    glyph = bkmod.MultiLine(xs='center_xs', ys='center_ys', line_color='red', line_width=2)\n",
+    "    fig1.add_glyph(source, glyph)\n",
     "    \n",
     "    hover = bkmod.HoverTool(tooltips=[\n",
     "        (\"Cohort\", '@cohort'),\n",
@@ -674,7 +682,7 @@
  "metadata": {
   "celltoolbar": "Tags",
   "kernelspec": {
-   "display_name": "selection-atlas",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },

--- a/workflow/notebooks/cohort-page.ipynb
+++ b/workflow/notebooks/cohort-page.ipynb
@@ -452,6 +452,16 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "f38b4d44",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df_samples[['latitude', 'longitude', 'taxon']].groupby(['latitude', 'longitude', 'taxon']).size().to_frame().rename(columns={0: 'count'}).reset_index()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "id": "2f8e30da",
    "metadata": {
     "tags": [
@@ -461,11 +471,14 @@
    "outputs": [],
    "source": [
     "from ipyleaflet import Map, Marker, basemaps\n",
+    "from ipywidgets import HTML\n",
     "\n",
     "center = cohort[['latitude', 'longitude']].to_list()\n",
     "m = Map(center=center, zoom=9, basemap=basemaps.OpenTopoMap)\n",
     "\n",
-    "for coh_id, row in df_samples.iterrows():\n",
+    "df = df_samples[['latitude', 'longitude', 'taxon']].groupby(['latitude', 'longitude', 'taxon']).size().to_frame().rename(columns={0: 'count'}).reset_index()\n",
+    "\n",
+    "for coh_id, row in df.iterrows():\n",
     "    lat, long = row[['latitude', 'longitude']]\n",
     "    \n",
     "    if row['taxon'] == 'gambiae':\n",
@@ -479,6 +492,10 @@
     "\n",
     "    marker = Marker(location=(lat, long), draggable=True, opacity=0.7, color=color)\n",
     "    m.add_layer(marker);\n",
+    "\n",
+    "    message2 = HTML()\n",
+    "    message2.value = f\"n = {row['count']}\"\n",
+    "    marker.popup = message2\n",
     "\n",
     "display(m)"
    ]

--- a/workflow/notebooks/cohort-page.ipynb
+++ b/workflow/notebooks/cohort-page.ipynb
@@ -38,6 +38,7 @@
    "source": [
     "from IPython.display import Markdown, HTML\n",
     "import malariagen_data\n",
+    "import numpy as np\n",
     "import pandas as pd\n",
     "from pyprojroot import here\n",
     "import yaml\n",
@@ -361,7 +362,7 @@
     "    quad2 = fig1.quad(bottom='bottom', top='top', left='focus_start', right='focus_stop', \n",
     "          source=source, color=\"red\", alpha=.4)\n",
     "    glyph = bkmod.MultiLine(xs='center_xs', ys='center_ys', line_color='red', line_width=2)\n",
-    "    fig1.add_glyph(source, glyph)\n",
+    "    fig1.add_glyph(source=source, glyph=glyph)\n",
     "    \n",
     "    hover = bkmod.HoverTool(tooltips=[\n",
     "        (\"Cohort\", '@cohort'),\n",

--- a/workflow/notebooks/cohort-page.ipynb
+++ b/workflow/notebooks/cohort-page.ipynb
@@ -364,7 +364,7 @@
     "    quad2 = fig1.quad(bottom='bottom', top='top', left='focus_start', right='focus_stop', \n",
     "          source=source, color=\"red\", alpha=.4)\n",
     "    glyph = bkmod.MultiLine(xs='center_xs', ys='center_ys', line_color='red', line_width=2)\n",
-    "    fig1.add_glyph(source=source, glyph=glyph)\n",
+    "    fig1.add_glyph(source, glyph)\n",
     "    \n",
     "    hover = bkmod.HoverTool(tooltips=[\n",
     "        (\"Cohort\", '@cohort'),\n",

--- a/workflow/notebooks/cohort-page.ipynb
+++ b/workflow/notebooks/cohort-page.ipynb
@@ -14,7 +14,7 @@
    "source": [
     "# Notebook parameters. Values here are for development only and \n",
     "# will be overridden when running via snakemake and papermill.\n",
-    "cohort_id = 'BF-09_Houet_colu_2012_Q3'\n",
+    "cohort_id = 'ML-2_Kati_colu_2014_Q3'\n",
     "cohorts_analysis = \"20230223\"\n",
     "contigs = ['3L']\n",
     "sample_sets = \"3.0\"\n",
@@ -48,6 +48,7 @@
     "import geopandas as gpd\n",
     "import bokeh.layouts as bklay\n",
     "import bokeh.plotting as bkplt\n",
+    "import bokeh.models as bkmod\n",
     "import plotly.express as px\n",
     "\n",
     "from bokeh.io import output_notebook # enables plot interface in J notebook\n",
@@ -271,6 +272,22 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "7b10b224",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# load signals to overlay on H12 plots\n",
+    "\n",
+    "df_signals = [\n",
+    "    pd.read_csv(here() / \"build/h12-signal-detection/\" / f\"{cohort_id}_{contig}.csv\")\n",
+    "    for contig in contigs\n",
+    "]\n",
+    "df_signals = pd.concat(df_signals).assign(bottom=0, top=1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "id": "212846ca",
    "metadata": {
     "tags": [
@@ -298,6 +315,7 @@
     "\n",
     "def plot_h12_g123_ihs_tracks(\n",
     "        contig, \n",
+    "        df_signals,\n",
     "        sizing_mode='stretch_width', \n",
     "        show=False, \n",
     "        width=800, \n",
@@ -305,6 +323,18 @@
     "    ):\n",
     "\n",
     "    sample_query = cohort[\"sample_query\"]\n",
+    "    df = df_signals.query(\"contig == @contig\")\n",
+    "    source = bkmod.ColumnDataSource(data={\n",
+    "        'cohort': df.cohort_id,\n",
+    "        'chromosome': df.contig,\n",
+    "        'score': df.delta_i.astype(int),\n",
+    "        'peak_start': df.span2_pstart,\n",
+    "        'peak_stop': df.span2_pstop,\n",
+    "        'focus_start': df.focus_pstart,\n",
+    "        'focus_stop': df.focus_pstop,    \n",
+    "        'bottom': df.bottom ,\n",
+    "        'top': df.top,\n",
+    "        })\n",
     "    \n",
     "    fig1 = ag3.plot_h12_gwss_track(\n",
     "        contig=contig, \n",
@@ -319,7 +349,20 @@
     "        width=width,\n",
     "    )\n",
     "    fig1.xaxis.visible = False\n",
+    "    \n",
+    "    quad = fig1.quad(bottom='bottom', top='top', left='peak_start', right='peak_stop', \n",
+    "          source=source, color=\"gray\", alpha=.1, line_width=1)\n",
+    "    quad2 = fig1.quad(bottom='bottom', top='top', left='focus_start', right='focus_stop', \n",
+    "          source=source, color=\"red\", alpha=.4)\n",
+    "    \n",
+    "    hover = bkmod.HoverTool(tooltips=[\n",
+    "        (\"Cohort\", '@cohort'),\n",
+    "        (\"Score\", '@score'),\n",
+    "        (\"Focus\", \"@focus_start{,} - @focus_stop{,}\"),\n",
+    "    ], renderers=[quad])\n",
     "\n",
+    "    fig1.add_tools(hover)\n",
+    "    \n",
     "    fig2 = ag3.plot_g123_gwss_track(\n",
     "        contig=contig, \n",
     "        window_size=g123_window_size, \n",
@@ -391,6 +434,7 @@
     "    \n",
     "    fig = plot_h12_g123_ihs_tracks(\n",
     "        contig=contig,\n",
+    "        df_signals=df_signals,\n",
     "    );\n",
     "\n",
     "    bkplt.show(fig)\n"
@@ -615,7 +659,7 @@
   "kernelspec": {
    "display_name": "selection-atlas",
    "language": "python",
-   "name": "selection-atlas"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -627,7 +671,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.11"
+   "version": "3.10.10"
   }
  },
  "nbformat": 4,

--- a/workflow/notebooks/cohort-page.ipynb
+++ b/workflow/notebooks/cohort-page.ipynb
@@ -63,6 +63,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "3a98f014",
    "metadata": {},
@@ -263,6 +264,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "3ff2d7fb",
    "metadata": {},
@@ -327,7 +329,7 @@
     "    df = df_signals.query(\"contig == @contig\")\n",
     "    \n",
     "    center_xs = [np.array([row.pcenter, row.pcenter]) for idx, row in df.iterrows()]\n",
-    "    center_ys = [np.array([row.level, row.level + .2]) for idx, row in df.iterrows()]\n",
+    "    center_ys = [np.array([0, 1]) for idx, row in df.iterrows()]\n",
     "\n",
     "    source = bkmod.ColumnDataSource(data={\n",
     "        'cohort': df.cohort_id,\n",
@@ -450,6 +452,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "518be38c",
    "metadata": {},
@@ -510,6 +513,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "a1526763",
    "metadata": {},
@@ -577,6 +581,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "d53794f4",
    "metadata": {},
@@ -612,6 +617,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "8d836cf6",
    "metadata": {},
@@ -645,6 +651,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "ecff988c",
    "metadata": {},


### PR DESCRIPTION
Addresses #39. 

This PR adds to the cohort page, loading the detected H12 signals and overlaying these signals as two shaded boxes.  

It currently looks like this, with gray shading for the wider region and red for the focal region. The Delta score and focus span is available as hovertext. 

![image](https://github.com/anopheles-genomic-surveillance/selection-atlas/assets/34922269/30dcdd38-4a9d-424b-9d8a-8b48d007ad6c)

Happy for suggestions on how to improve the appearance of this further, cc @alimanfoo 