### PR TITLE
remove dup tooltips on chromosome signal plots  

### DIFF
--- a/workflow/notebooks/chromosome-page.ipynb
+++ b/workflow/notebooks/chromosome-page.ipynb
@@ -220,12 +220,17 @@
     "        (\"Focus\", \"@focus_start{,} - @focus_stop{,}\"),\n",
     "    ])\n",
     "\n",
+    "xwheel_zoom = bkmod.WheelZoomTool(\n",
+    "    dimensions=\"width\", maintain_focus=False\n",
+    ")\n",
+    "\n",
+    "x_range = bkmod.Range1d(0, ag3.genome_sequence(contig).shape[0], bounds='auto')\n",
+    "\n",
     "# make figure \n",
     "fig1 = bkplt.figure(title='Selection signals',\n",
     "                  width=900, height=200 + (10 * max(df.level)), \n",
-    "                  tools=\"tap,xpan,xzoom_in,xzoom_out,xwheel_zoom,reset\".split() + [hover],\n",
-    "                  toolbar_location='above', active_drag='xpan', active_scroll='xwheel_zoom')\n",
-    "\n",
+    "                  tools=\"xpan,xzoom_in,xzoom_out,reset\".split() + [hover, xwheel_zoom], \n",
+    "                  active_scroll=xwheel_zoom, sizing_mode='stretch_width', x_range=x_range, active_inspect=None)\n",
     "\n",
     "fig1.patches(xs='left_xs', ys='left_ys', source=source, color=\"color\", alpha=.7, line_width=2, legend_field='taxon')\n",
     "\n",
@@ -237,7 +242,6 @@
     "\n",
     "fig1.patches(xs='right_xs', ys='right_ys', source=source, color=\"color\", alpha=.7, line_width=2, legend_field='taxon')\n",
     "\n",
-    "fig1.x_range = bkmod.Range1d(0, ag3.genome_sequence(contig).shape[0], bounds='auto')\n",
     "fig1.y_range = bkmod.Range1d(-0.5, max(df.level) + 1.3, bounds='auto')\n",
     "fig1.x_range.max_interval = ag3.genome_sequence(contig).shape[0]\n",
     "fig1.yaxis.visible = False\n",
@@ -303,9 +307,9 @@
  "metadata": {
   "celltoolbar": "Tags",
   "kernelspec": {
-   "display_name": "sanjaynagi-selection-atlas",
+   "display_name": "selection-atlas",
    "language": "python",
-   "name": "conda-env-sanjaynagi-selection-atlas-py"
+   "name": "selection-atlas"
   },
   "language_info": {
    "codemirror_mode": {


### PR DESCRIPTION
This PR removes duplicated tooltips on the chromosome pages. 

Unfortunately, the Xwheelzoom only works on the genes plot, and not the signals plot. I cant figure this out but doing this for now. 