### PR TITLE
Build version 2025.02.13 with Ag3.0 sample sets

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,15 +5,21 @@ on:
     branches:
       - main
 
-env:
-  ANALYSIS_VERSION: "2025.02.12"
-
 jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
         uses: actions/checkout@v3
+
+      - name: Get analysis version
+        id: get_analysis_version
+        uses: mikefarah/yq@master
+        with:
+          cmd: yq '.analysis_version' config/main.yaml
+
+      - name: Echo analysis version
+        run: echo ${{ steps.get_analysis_version.outputs.result }}
 
       - name: Install conda environment
         uses: mamba-org/setup-micromamba@v2
@@ -50,7 +56,7 @@ jobs:
 
       - name: Link to publication directory
         run: |
-          ln -sv results/${ANALYSIS_VERSION}/site/docs/_build/html public
+          ln -sv results/${{ steps.get_analysis_version.outputs.result }}/site/docs/_build/html public
 
       - name: Publish to GitHub Pages
         uses: peaceiris/actions-gh-pages@v3

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,6 +9,15 @@ jobs:
       - name: Checkout source
         uses: actions/checkout@v4
 
+      - name: Get analysis version
+        id: get_analysis_version
+        uses: mikefarah/yq@master
+        with:
+          cmd: yq '.analysis_version' config/main.yaml
+
+      - name: Echo analysis version
+        run: echo ${{ steps.get_analysis_version.outputs.result }}
+
       - name: Run pre-commit checks
         uses: pre-commit/action@v3.0.0
 
@@ -20,7 +29,7 @@ jobs:
           cache-downloads: true
 
       # Snakemake linting requires Google Cloud authentication, because it runs the
-      # workflow/common/scripts/setup.py script.
+      # workflow/common/scripts/setup.py script, which initialises malariagen_data.
       - id: auth
         name: Set up Google Cloud authentication
         uses: google-github-actions/auth@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,9 +27,9 @@ jobs:
       - name: Restore results cache
         uses: actions/cache/restore@v3
         with:
-          path: results/malariagen_data_cache
+          path: results
           # Change this key if you ever want to force clear the cache.
-          key: results_cache_20230512
+          key: results_cache_20250213
 
       - name: Install conda environment
         uses: mamba-org/setup-micromamba@v2
@@ -41,17 +41,17 @@ jobs:
       - name: Run gwss snakemake workflow
         shell: bash -l {0}
         run: |
-          snakemake -c1 --configfile config/ci.yaml --snakefile workflow/gwss/Snakefile --show-failed-logs
+          snakemake -c1 --configfile config/ci.yaml --snakefile workflow/gwss/Snakefile --show-failed-logs --forceall
 
       - name: Run site snakemake workflow
         shell: bash -l {0}
         run: |
-          snakemake -c1 --configfile config/ci.yaml --snakefile workflow/site/Snakefile --show-failed-logs
+          snakemake -c1 --configfile config/ci.yaml --snakefile workflow/site/Snakefile --show-failed-logs --forceall
 
       - name: Save results cache
         uses: actions/cache/save@v3
         if: always()
         with:
-          path: results/malariagen_data_cache
+          path: results
           # Change this key if you ever want to force clear the cache.
-          key: results_cache_20230512
+          key: results_cache_20250213

--- a/README.md
+++ b/README.md
@@ -68,13 +68,13 @@ Please note that this workflow will generally require a lot of computation and d
 During development, you may want to run the workflow without any parallelisation:
 
 ```
-snakemake -c1 --snakefile workflow/gwss/Snakefile --show-failed-logs
+MGEN_SHOW_PROGRESS=0 snakemake -c1 --snakefile workflow/gwss/Snakefile --show-failed-logs
 ```
 
 To run the workflow fully, you can try running with parallelisation. Note this will need to be on a machine with sufficient cores and memory. E.g.:
 
 ```
-snakemake -c4 --snakefile workflow/gwss/Snakefile --show-failed-logs
+MGEN_SHOW_PROGRESS=0 snakemake -c4 --snakefile workflow/gwss/Snakefile --show-failed-logs
 ```
 
 The outputs of the gwss workflow will be stored in the "results" folder, under a sub-folder named according to the "analysis_version" parameter given in the workflow configuration file.
@@ -103,7 +103,7 @@ find results -type f -exec touch {} +
 The site workflow will use the outputs from the gwss workflow and compile all of the content for the selection atlas website. To run this workflow:
 
 ```
-MGEN_SHOW_PROGRESS=0 snakemake -c1 --snakefile workflow/site.smk
+MGEN_SHOW_PROGRESS=0 snakemake -c1 --snakefile workflow/site/Snakefile --show-failed-logs
 ```
 
 You can run this workflow on a smaller computer as it should not need to perform any heavy computations.

--- a/README.md
+++ b/README.md
@@ -68,13 +68,13 @@ Please note that this workflow will generally require a lot of computation and d
 During development, you may want to run the workflow without any parallelisation:
 
 ```
-snakemake -c1 --snakefile workflow/gwss/Snakefile
+snakemake -c1 --snakefile workflow/gwss/Snakefile --show-failed-logs
 ```
 
 To run the workflow fully, you can try running with parallelisation. Note this will need to be on a machine with sufficient cores and memory. E.g.:
 
 ```
-snakemake -c4 --snakefile workflow/gwss/Snakefile
+snakemake -c4 --snakefile workflow/gwss/Snakefile --show-failed-logs
 ```
 
 The outputs of the gwss workflow will be stored in the "results" folder, under a sub-folder named according to the "analysis_version" parameter given in the workflow configuration file.

--- a/config/main.yaml
+++ b/config/main.yaml
@@ -2,23 +2,18 @@
 # the outputs from a particular run of the analysis workflow. If you
 # change any of the parameters in this configuration file then please
 # also update the analysis version.
-analysis_version: "2025.02.12"
+analysis_version: "2025.02.13"
 
 # Set minimum and maximum cohort size parameters.
 min_cohort_size: 15
-max_cohort_size: 50  # TODO Maybe increase this for production?
+max_cohort_size: 70  # TODO Maybe increase this for production?
 
 # Select the sample sets to include in the analysis.
 sample_sets:
-    # - "3.0"
-    # smaller dataset for development
-    - "AG1000G-ML-A"
-    - "AG1000G-BF-A"
-    - "AG1000G-AO"
-    - "AG1000G-CD"
-    - "AG1000G-CI"
-    - "AG1000G-UG"
-    - "AG1000G-TZ"
+    - "3.0"
+
+# Filter samples to include in the analysis.
+sample_query: "unrestricted_use and taxon in ['gambiae', 'coluzzii', 'arabiensis', 'bissau']"
 
 # Select the contigs to analyse.
 contigs:

--- a/workflow/gwss/notebooks/h12-calibration.ipynb
+++ b/workflow/gwss/notebooks/h12-calibration.ipynb
@@ -262,8 +262,14 @@
  ],
  "metadata": {
   "celltoolbar": "Tags",
+  "environment": {
+   "kernel": "python3",
+   "name": "workbench-notebooks.m125",
+   "type": "gcloud",
+   "uri": "us-docker.pkg.dev/deeplearning-platform-release/gcr.io/workbench-notebooks:m125"
+  },
   "kernelspec": {
-   "display_name": "Python 3.12.8",
+   "display_name": "bissau-cryptic-taxon",
    "language": "python",
    "name": "python3"
   },
@@ -277,7 +283,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.8"
+   "version": "3.12.7"
   },
   "vscode": {
    "interpreter": {

--- a/workflow/gwss/notebooks/h12-calibration.ipynb
+++ b/workflow/gwss/notebooks/h12-calibration.ipynb
@@ -263,15 +263,15 @@
  "metadata": {
   "celltoolbar": "Tags",
   "environment": {
-   "kernel": "python3",
+   "kernel": "selection-atlas",
    "name": "workbench-notebooks.m125",
    "type": "gcloud",
    "uri": "us-docker.pkg.dev/deeplearning-platform-release/gcr.io/workbench-notebooks:m125"
   },
   "kernelspec": {
-   "display_name": "bissau-cryptic-taxon",
+   "display_name": "selection-atlas",
    "language": "python",
-   "name": "python3"
+   "name": "selection-atlas"
   },
   "language_info": {
    "codemirror_mode": {
@@ -283,7 +283,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.7"
+   "version": "3.12.8"
   },
   "vscode": {
    "interpreter": {

--- a/workflow/gwss/notebooks/setup-cohorts.ipynb
+++ b/workflow/gwss/notebooks/setup-cohorts.ipynb
@@ -24,6 +24,7 @@
     "# Notebook parameters. Values here are for development only and\n",
     "# will be overridden when running via snakemake and papermill.\n",
     "sample_sets = \"AG1000G-BF-A\"\n",
+    "sample_query = None\n",
     "contigs = [\"3L\"]\n",
     "cohorts_analysis = \"20240924\"\n",
     "min_cohort_size = 20\n",
@@ -56,7 +57,7 @@
    },
    "outputs": [],
    "source": [
-    "df_samples = ag3.sample_metadata(sample_sets=sample_sets)"
+    "df_samples = ag3.sample_metadata(sample_sets=sample_sets, sample_query=sample_query)"
    ]
   },
   {
@@ -216,8 +217,14 @@
   }
  ],
  "metadata": {
+  "environment": {
+   "kernel": "python3",
+   "name": "workbench-notebooks.m125",
+   "type": "gcloud",
+   "uri": "us-docker.pkg.dev/deeplearning-platform-release/gcr.io/workbench-notebooks:m125"
+  },
   "kernelspec": {
-   "display_name": "Python 3.12.8",
+   "display_name": "bissau-cryptic-taxon",
    "language": "python",
    "name": "python3"
   },
@@ -231,7 +238,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.8"
+   "version": "3.12.7"
   },
   "vscode": {
    "interpreter": {

--- a/workflow/gwss/notebooks/setup-cohorts.ipynb
+++ b/workflow/gwss/notebooks/setup-cohorts.ipynb
@@ -218,15 +218,15 @@
  ],
  "metadata": {
   "environment": {
-   "kernel": "python3",
+   "kernel": "selection-atlas",
    "name": "workbench-notebooks.m125",
    "type": "gcloud",
    "uri": "us-docker.pkg.dev/deeplearning-platform-release/gcr.io/workbench-notebooks:m125"
   },
   "kernelspec": {
-   "display_name": "bissau-cryptic-taxon",
+   "display_name": "selection-atlas",
    "language": "python",
-   "name": "python3"
+   "name": "selection-atlas"
   },
   "language_info": {
    "codemirror_mode": {
@@ -238,7 +238,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.7"
+   "version": "3.12.8"
   },
   "vscode": {
    "interpreter": {

--- a/workflow/site/notebooks/country-page.ipynb
+++ b/workflow/site/notebooks/country-page.ipynb
@@ -15,7 +15,8 @@
     "# Notebook parameters. Values here are for development only and\n",
     "# will be overridden when running via snakemake and papermill.\n",
     "country = \"ML\"\n",
-    "analysis_version = \"2025.02.07\"\n",
+    "contigs = [\"3L\"]\n",
+    "analysis_version = \"2025.02.13\"\n",
     "dask_scheduler = \"single-threaded\"\n",
     "cohorts_analysis = \"20240924\""
    ]
@@ -52,12 +53,6 @@
    "source": [
     "# Country Foo"
    ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "d8675443",
-   "metadata": {},
-   "source": []
   },
   {
    "cell_type": "markdown",
@@ -102,7 +97,9 @@
     "center = gdf_cohorts[[\"latitude\", \"longitude\"]].mean().to_list()\n",
     "m = Map(center=center, zoom=7, basemap=basemaps.OpenTopoMap)\n",
     "\n",
-    "for shapeID in gdf_cohorts.shapeID.unique():\n",
+    "for shapeID in gdf_cohorts_country.shapeID.unique():\n",
+    "    if shapeID is None:\n",
+    "        continue\n",
     "    df = gdf_cohorts.query(\"shapeID == @shapeID\")\n",
     "    html_text = \"<br>\".join(\n",
     "        [\n",
@@ -206,6 +203,12 @@
  ],
  "metadata": {
   "celltoolbar": "Tags",
+  "environment": {
+   "kernel": "selection-atlas",
+   "name": "workbench-notebooks.m125",
+   "type": "gcloud",
+   "uri": "us-docker.pkg.dev/deeplearning-platform-release/gcr.io/workbench-notebooks:m125"
+  },
   "kernelspec": {
    "display_name": "selection-atlas",
    "language": "python",
@@ -221,7 +224,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.11"
+   "version": "3.12.8"
   }
  },
  "nbformat": 4,

--- a/workflow/site/notebooks/home-page.ipynb
+++ b/workflow/site/notebooks/home-page.ipynb
@@ -14,7 +14,7 @@
    "source": [
     "# Parameters from the workflow config.yaml.\n",
     "cohorts_analysis = \"20240924\"\n",
-    "analysis_version = \"2025.02.12\"\n",
+    "analysis_version = \"2025.02.13\"\n",
     "dask_scheduler = \"single-threaded\"\n",
     "contigs = [\"3L\"]"
    ]
@@ -69,6 +69,8 @@
     "m = Map(center=center, zoom=3, basemap=basemaps.OpenTopoMap)\n",
     "\n",
     "for shapeID in gdf_cohorts.shapeID.unique():\n",
+    "    if shapeID is None:\n",
+    "        continue\n",
     "    df = gdf_cohorts.query(\"shapeID == @shapeID\")\n",
     "    html_text = \"<br>\".join(\n",
     "        [\n",
@@ -92,14 +94,28 @@
     "\n",
     "display(m)"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ebaaf4fd-8f63-4ac3-9768-f42c4b641f34",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
   "celltoolbar": "Tags",
+  "environment": {
+   "kernel": "selection-atlas",
+   "name": "workbench-notebooks.m125",
+   "type": "gcloud",
+   "uri": "us-docker.pkg.dev/deeplearning-platform-release/gcr.io/workbench-notebooks:m125"
+  },
   "kernelspec": {
-   "display_name": "Python 3.12.8",
+   "display_name": "selection-atlas",
    "language": "python",
-   "name": "python3"
+   "name": "selection-atlas"
   },
   "language_info": {
    "codemirror_mode": {


### PR DESCRIPTION
* Bump the analysis version to 2025.02.13
* Expand the sample sets to all in Ag3.0
* Add a `sample_query` configuration parameter to allow for additional control on which cohorts are included
* Fix some bugs
* Update the deploy action to automatically detect the current analysis version from the workflow config