### PR TITLE
Fix H12 plot colors in cohort pages

### DIFF
--- a/workflow/site/notebooks/alert-page.ipynb
+++ b/workflow/site/notebooks/alert-page.ipynb
@@ -42,8 +42,9 @@
     "]\n",
     "\n",
     "# Parameters from the workflow config.yaml.\n",
+    "contigs = [\"2RL\", \"3RL\", \"X\"]\n",
     "cohorts_analysis = \"20240924\"\n",
-    "analysis_version = \"2025.02.11\"\n",
+    "analysis_version = \"2025.02.13\"\n",
     "dask_scheduler = \"single-threaded\""
    ]
   },
@@ -206,9 +207,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3.12.8 (conda)",
+   "display_name": "selection-atlas",
    "language": "python",
-   "name": "python3"
+   "name": "selection-atlas"
   },
   "language_info": {
    "codemirror_mode": {

--- a/workflow/site/notebooks/cohort-page.ipynb
+++ b/workflow/site/notebooks/cohort-page.ipynb
@@ -343,8 +343,8 @@
     "            left=\"peak_start\",\n",
     "            right=\"peak_stop\",\n",
     "            source=source,\n",
-    "            color=\"#D7B2A6\",\n",
-    "            alpha=0.3,\n",
+    "            color=signal_span_color,\n",
+    "            alpha=signal_span_alpha,\n",
     "            line_width=1,\n",
     "            level=\"underlay\",\n",
     "        )\n",
@@ -354,16 +354,16 @@
     "            left=\"focus_start\",\n",
     "            right=\"focus_stop\",\n",
     "            source=source,\n",
-    "            color=\"red\",\n",
-    "            alpha=0.4,\n",
+    "            color=signal_focus_color,\n",
+    "            alpha=signal_focus_alpha,\n",
     "            level=\"underlay\",\n",
     "        )\n",
     "        glyph = bkmod.MultiLine(\n",
     "            xs=\"center_xs\",\n",
     "            ys=\"center_ys\",\n",
-    "            line_color=\"red\",\n",
+    "            line_color=signal_center_color,\n",
     "            line_width=2,\n",
-    "            line_alpha=0.8,\n",
+    "            line_alpha=signal_center_alpha,\n",
     "        )\n",
     "        fig1.add_glyph(source, glyph)\n",
     "\n",
@@ -676,9 +676,9 @@
  "metadata": {
   "celltoolbar": "Tags",
   "kernelspec": {
-   "display_name": "alimanfoo-selection-atlas-2025-02-11",
+   "display_name": "selection-atlas",
    "language": "python",
-   "name": "conda-env-alimanfoo-selection-atlas-2025-02-11-py"
+   "name": "selection-atlas"
   },
   "language_info": {
    "codemirror_mode": {

--- a/workflow/site/notebooks/cohort-page.ipynb
+++ b/workflow/site/notebooks/cohort-page.ipynb
@@ -14,16 +14,18 @@
    "source": [
     "# Notebook parameters. Values here are for development only and\n",
     "# will be overridden when running via snakemake and papermill.\n",
+    "\n",
     "# cohort_id = \"CD-NU_Gbadolite_gamb_2015_Q3\"\n",
     "cohort_id = \"ML-2_Kati_colu_2014_Q3\"\n",
     "# cohort_id = 'CI-LG_Agneby-Tiassa_colu_2012'\n",
-    "cohorts_analysis = \"20240924\"\n",
+    "\n",
+    "analysis_version = \"2025.02.13\"\n",
+    "min_cohort_size = 15\n",
+    "max_cohort_size = 70\n",
     "sample_sets = \"3.0\"\n",
-    "analysis_version = \"2025.02.07\"\n",
-    "dask_scheduler = \"single-threaded\"\n",
     "contigs = [\"2RL\", \"3RL\", \"X\"]\n",
-    "min_cohort_size = 20\n",
-    "max_cohort_size = 50"
+    "cohorts_analysis = \"20240924\"\n",
+    "dask_scheduler = \"single-threaded\""
    ]
   },
   {
@@ -269,6 +271,8 @@
    },
    "outputs": [],
    "source": [
+    "import bokeh.palettes as bkpal\n",
+    "\n",
     "# load window sizes\n",
     "with open(here() / h12_calibration_dir / f\"{cohort_id}.yaml\") as h12_calibration_file:\n",
     "    h12_calibration_params = yaml.safe_load(h12_calibration_file)\n",
@@ -285,7 +289,7 @@
     "ihs_window_size = 100\n",
     "\n",
     "\n",
-    "def plot_h12_g123_ihs_tracks(\n",
+    "def plot_gwss(\n",
     "    contig,\n",
     "    df_signals,\n",
     "    sizing_mode=\"stretch_width\",\n",
@@ -295,6 +299,8 @@
     "    genes_height=90,\n",
     "):\n",
     "    sample_query = cohort[\"sample_query\"]\n",
+    "\n",
+    "    h12_palette = list(bkpal.BuPu4[0:1])\n",
     "\n",
     "    fig1 = ag3.plot_h12_gwss_track(\n",
     "        contig=contig,\n",
@@ -308,6 +314,7 @@
     "        show=show,\n",
     "        width=width,\n",
     "        height=track_height,\n",
+    "        contig_colors=h12_palette,\n",
     "    )\n",
     "    fig1.xaxis.visible = False\n",
     "\n",
@@ -336,20 +343,21 @@
     "            left=\"peak_start\",\n",
     "            right=\"peak_stop\",\n",
     "            source=source,\n",
-    "            color=\"gray\",\n",
-    "            alpha=0.1,\n",
+    "            color=\"#D7B2A6\",\n",
+    "            alpha=0.3,\n",
     "            line_width=1,\n",
+    "            level=\"underlay\",\n",
     "        )\n",
-    "        # TODO this is unused, need to check all good here?\n",
-    "        # quad2 = fig1.quad(\n",
-    "        #     bottom=\"bottom\",\n",
-    "        #     top=\"top\",\n",
-    "        #     left=\"focus_start\",\n",
-    "        #     right=\"focus_stop\",\n",
-    "        #     source=source,\n",
-    "        #     color=\"red\",\n",
-    "        #     alpha=0.4,\n",
-    "        # )\n",
+    "        fig1.quad(\n",
+    "            bottom=\"bottom\",\n",
+    "            top=\"top\",\n",
+    "            left=\"focus_start\",\n",
+    "            right=\"focus_stop\",\n",
+    "            source=source,\n",
+    "            color=\"red\",\n",
+    "            alpha=0.4,\n",
+    "            level=\"underlay\",\n",
+    "        )\n",
     "        glyph = bkmod.MultiLine(\n",
     "            xs=\"center_xs\",\n",
     "            ys=\"center_ys\",\n",
@@ -439,7 +447,7 @@
     "for contig in contigs:\n",
     "    display(HTML(f\"<h3>Chromosome {contig}</h3>\"))\n",
     "\n",
-    "    fig = plot_h12_g123_ihs_tracks(\n",
+    "    fig = plot_gwss(\n",
     "        contig=contig,\n",
     "        df_signals=df_signals,\n",
     "    )\n",
@@ -465,9 +473,6 @@
    },
    "outputs": [],
    "source": [
-    "from ipyleaflet import Map, Marker, basemaps\n",
-    "from ipywidgets import HTML\n",
-    "\n",
     "center = cohort[[\"latitude\", \"longitude\"]].to_list()\n",
     "m = Map(center=center, zoom=9, basemap=basemaps.OpenTopoMap)\n",
     "\n",
@@ -671,9 +676,9 @@
  "metadata": {
   "celltoolbar": "Tags",
   "kernelspec": {
-   "display_name": "selection-atlas",
+   "display_name": "alimanfoo-selection-atlas-2025-02-11",
    "language": "python",
-   "name": "python3"
+   "name": "conda-env-alimanfoo-selection-atlas-2025-02-11-py"
   },
   "language_info": {
    "codemirror_mode": {
@@ -685,7 +690,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.10"
+   "version": "3.12.8"
   }
  },
  "nbformat": 4,

--- a/workflow/site/scripts/page-setup.py
+++ b/workflow/site/scripts/page-setup.py
@@ -186,7 +186,7 @@ def plot_signals(
         right="focus_pstop",
         source=source,
         color="red",
-        alpha=0.5,
+        alpha=0.4,
         line_width=2,
     )
 

--- a/workflow/site/scripts/page-setup.py
+++ b/workflow/site/scripts/page-setup.py
@@ -21,6 +21,15 @@ from bokeh.io import output_notebook  # noqa
 gdf_cohorts = gpd.read_file(final_cohorts_geojson_file)
 
 
+# Colours for signal plotting.
+signal_span_color = "#D7B2A6"
+signal_span_alpha = 0.6
+signal_focus_color = "red"
+signal_focus_alpha = 0.4
+signal_center_color = "red"
+signal_center_alpha = 1.0
+
+
 def stack_overlaps(df, start_col, end_col, tolerance=10000):
     """Stack overlapping objects."""
     occupants = [None]
@@ -72,7 +81,7 @@ def load_signals(contig, start=None, stop=None):
     # df_signals['color'] = df_signals['taxon'].map(color_dict).fillna('lightgrey')
 
     # Fixed color.
-    df_signals["color"] = "#D7B2A6"
+    df_signals["color"] = signal_span_color
 
     # Filter to region.
     if start and stop:
@@ -166,16 +175,16 @@ def plot_signals(
         xs="left_xs",
         ys="left_ys",
         source=source,
-        color="color",
-        alpha=0.7,
+        color=signal_span_color,
+        alpha=signal_span_alpha,
         line_width=2,
     )
     fig1.patches(
         xs="right_xs",
         ys="right_ys",
         source=source,
-        color="color",
-        alpha=0.7,
+        color=signal_span_color,
+        alpha=signal_span_alpha,
         line_width=2,
     )
 
@@ -185,17 +194,17 @@ def plot_signals(
         left="focus_pstart",
         right="focus_pstop",
         source=source,
-        color="red",
-        alpha=0.4,
+        color=signal_focus_color,
+        alpha=signal_focus_alpha,
         line_width=2,
     )
 
     glyph = bkmod.MultiLine(
         xs="center_xs",
         ys="center_ys",
-        line_color="red",
+        line_color=signal_center_color,
         line_width=2,
-        line_alpha=0.8,
+        line_alpha=signal_center_alpha,
     )
     fig1.add_glyph(source, glyph)
 


### PR DESCRIPTION
* Use the same colour in H12 plots for all contigs, for consistency.
* Reinstate the red shading of the focus region on the H12 tracks (accidentally commented out previously).
* Consistify signal colors between signals plots and H12 plots.